### PR TITLE
docs: typo Clou → Cloud in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This installs dependencies, builds your project, and starts your server. You’r
 
 ## Resources
 
-[Docs](https://docs.strapi.io) • [Demo](https://strapi.io/demo) • [Forum](https://forum.strapi.io/) • [Discord](https://discord.strapi.io) • [Youtube](https://www.youtube.com/c/Strapi/featured) • [Strapi Design System](https://design-system.strapi.io/) • [Marketplace](https://market.strapi.io/) • [Clou Free Trial](https://cloud.strapi.io) 
+[Docs](https://docs.strapi.io) • [Demo](https://strapi.io/demo) • [Forum](https://forum.strapi.io/) • [Discord](https://discord.strapi.io) • [Youtube](https://www.youtube.com/c/Strapi/featured) • [Strapi Design System](https://design-system.strapi.io/) • [Marketplace](https://market.strapi.io/) • [Cloud Free Trial](https://cloud.strapi.io) 
 
 ## Todo
 


### PR DESCRIPTION
### What does it do?

Fix typo [Clou Free Trial](https://cloud.strapi.io/) in [README.md](https://github.com/strapi/LaunchPad/blob/main/README.md).

### Why is it needed?

To improve documentation.

### How to test it?

N/A

Some additional things to check:

- [ ] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
- [ ] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.
- [ ] Strapi version is the latest possible.

### Related issue(s)/PR(s)

N/A