### PR TITLE
chore: update Strapi version

### DIFF
--- a/strapi/package.json
+++ b/strapi/package.json
@@ -19,10 +19,10 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@strapi/plugin-cloud": "5.3.0",
+    "@strapi/plugin-cloud": "5.4.2",
     "@strapi/plugin-seo": "^2.0.4",
-    "@strapi/plugin-users-permissions": "5.3.0",
-    "@strapi/strapi": "5.3.0",
+    "@strapi/plugin-users-permissions": "5.4.2",
+    "@strapi/strapi": "5.4.2",
     "better-sqlite3": "9.4.3",
     "patch-package": "^8.0.0",
     "pluralize": "^8.0.0",

--- a/strapi/yarn.lock
+++ b/strapi/yarn.lock
@@ -1751,22 +1751,22 @@
     escape-string-regexp "^2.0.0"
     lodash.deburr "^4.1.0"
 
-"@strapi/admin@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-5.3.0.tgz#f2826e17c06da6f86995578de40a3dbdb5e6e57a"
-  integrity sha512-3IPKAg2iHxTGt3Pwg9sJmAEK3BIeziyTyZrG1UMaRSAsSfUYg2XcC+uY65iFVpiuNqnKJ0ShUciqlEPYfvdMew==
+"@strapi/admin@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-5.4.2.tgz#d1638c661789abd6bbb1baaab90f0bd0a6466cb9"
+  integrity sha512-MhUXBQpXe3+Tm5RS3uUJc280ONIQF74zSPmbKHK8/ayPfjCbEZbR+cnaZEOb0hLsNYF6S6bsdqMmEdAiP7mO7g==
   dependencies:
     "@casl/ability" "6.5.0"
     "@internationalized/date" "3.5.4"
     "@radix-ui/react-context" "1.0.1"
     "@radix-ui/react-toolbar" "1.0.4"
     "@reduxjs/toolkit" "1.9.7"
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/permissions" "5.3.0"
-    "@strapi/types" "5.3.0"
-    "@strapi/typescript-utils" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/permissions" "5.4.2"
+    "@strapi/types" "5.4.2"
+    "@strapi/typescript-utils" "5.4.2"
+    "@strapi/utils" "5.4.2"
     "@testing-library/dom" "10.1.0"
     "@testing-library/react" "15.0.7"
     "@testing-library/user-event" "14.5.2"
@@ -1820,13 +1820,14 @@
     yup "0.32.9"
     zod "^3.22.4"
 
-"@strapi/cloud-cli@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/cloud-cli/-/cloud-cli-5.3.0.tgz#382a1b93a2618eabe39f4e4b10ed732b74e4a08e"
-  integrity sha512-9vzfVXhefrwP7Ov+2LSm+hvzKIH/jLUtyCYUqaa4JbkMsbPsYNukoWWpKIE9RB7EEqkkW6kTQSGSqPEZ6E0taQ==
+"@strapi/cloud-cli@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/cloud-cli/-/cloud-cli-5.4.2.tgz#6f65f13fcac3ab12c6a727ca48ecc8bcfe5ae8c8"
+  integrity sha512-Vl7cLDmMB0+KAMlpibA21YemX3d5sFqMS5tn2DEQDHgL9GdJCYA2wfmd/IkFsFgHSpRqgSfeGj31Mkf4fwJweA==
   dependencies:
-    "@strapi/utils" "5.3.0"
+    "@strapi/utils" "5.4.2"
     axios "1.7.4"
+    boxen "5.1.2"
     chalk "4.1.2"
     cli-progress "3.12.0"
     commander "8.3.0"
@@ -1845,18 +1846,18 @@
     xdg-app-paths "8.3.0"
     yup "0.32.9"
 
-"@strapi/content-manager@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/content-manager/-/content-manager-5.3.0.tgz#84afe3c6a049ccfc9df735efd9c7694a0d3ceefa"
-  integrity sha512-6/0GiVooa8WL3vH456F2QYRFHzaorAt8Fem4Sc4vfQuguKXo/SwjAHI92MWxsFlXTu2lpJiTMdh9UCgct9VQlA==
+"@strapi/content-manager@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/content-manager/-/content-manager-5.4.2.tgz#c297b3ed3cc9fac237a13be38d11dac635dea5b5"
+  integrity sha512-1FCasLWZ37d5VksJqw89/UVMugdiVzylE9gN0Lm6dbBatl0baCTOEBAznY1MqN64lsl4klIAe7yQfroY8tcsng==
   dependencies:
     "@radix-ui/react-toolbar" "1.0.4"
     "@reduxjs/toolkit" "1.9.7"
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/types" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/types" "5.4.2"
+    "@strapi/utils" "5.4.2"
     codemirror5 "npm:codemirror@^5.65.11"
     date-fns "2.30.0"
     fractional-indexing "3.2.0"
@@ -1889,17 +1890,17 @@
     slate-react "0.98.3"
     yup "0.32.9"
 
-"@strapi/content-releases@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/content-releases/-/content-releases-5.3.0.tgz#49d1686b56eb034c817e505544bcad0852711071"
-  integrity sha512-JuPNiYRy91udKBt9a5eD11w5jHO2iI6ZFGYhDEkU3QKcVmtt7XqNbf2ERGNVnjZMTIjIYjWaCEDt282dccdrgg==
+"@strapi/content-releases@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/content-releases/-/content-releases-5.4.2.tgz#4fe2f408802cb6ddc0418fa5fd8a66ee9bf8a644"
+  integrity sha512-lSdvSzJOUct3TznxoBZO8frXxWVYLptx/Eg7Ti6YfEzuQkM83DOUrYtVKQ8KMPfc9QrhICbB33ZV1LaAsJQYyg==
   dependencies:
     "@reduxjs/toolkit" "1.9.7"
-    "@strapi/database" "5.3.0"
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/types" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/database" "5.4.2"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/types" "5.4.2"
+    "@strapi/utils" "5.4.2"
     date-fns "2.30.0"
     date-fns-tz "2.0.1"
     formik "2.4.5"
@@ -1910,17 +1911,17 @@
     react-redux "8.1.3"
     yup "0.32.9"
 
-"@strapi/content-type-builder@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/content-type-builder/-/content-type-builder-5.3.0.tgz#acc54c29b4a15597aedf573c79a8c2e22f9ad8f1"
-  integrity sha512-PUgWJu0HBz0JB63LAEf/QBWaURkN/iQ88JUCOGrdr61kCfnV9b340FvyltD39lioTs1zT00T7wB8w8JGzJfARw==
+"@strapi/content-type-builder@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/content-type-builder/-/content-type-builder-5.4.2.tgz#1e41809a8518a439dd1039ea34aa69ee4676c26b"
+  integrity sha512-DxDbQs3meuFLx1OngyAHseSGYzr6pHNZXdKx2O08o2mLfeG/ALl1YYMdkQg+bN3Nn6aAKwQP/UMKPGHTpKG8Bg==
   dependencies:
     "@reduxjs/toolkit" "1.9.7"
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/generators" "5.3.0"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/utils" "5.3.0"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/generators" "5.4.2"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/utils" "5.4.2"
     date-fns "2.30.0"
     fs-extra "11.2.0"
     immer "9.0.21"
@@ -1931,23 +1932,23 @@
     react-redux "8.1.3"
     yup "0.32.9"
 
-"@strapi/core@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/core/-/core-5.3.0.tgz#9e3a9faa0743c69c1cc94bf4c44e03c5f64b0d1f"
-  integrity sha512-b7E+KCzR18Li4l1NcIrWK/GErr7LCnjmj7ogTCgkWe4ZFk1cC4UAm2q76/hSY9S9jD46E1Uf4JsJTNTl7NqpXw==
+"@strapi/core@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/core/-/core-5.4.2.tgz#5d2e610cce6db641fcde26ac13fba00777dd497b"
+  integrity sha512-sP5+hwv2HPMddXR/fHMv4HDOy6sVOSJOwIF16VCR3qO0uHVVbdvAFPm/0O9hSoVn0UEezQGKAxuVON/vwdgK1g==
   dependencies:
     "@koa/cors" "5.0.0"
     "@koa/router" "12.0.2"
     "@paralleldrive/cuid2" "2.2.2"
-    "@strapi/admin" "5.3.0"
-    "@strapi/database" "5.3.0"
-    "@strapi/generators" "5.3.0"
-    "@strapi/logger" "5.3.0"
+    "@strapi/admin" "5.4.2"
+    "@strapi/database" "5.4.2"
+    "@strapi/generators" "5.4.2"
+    "@strapi/logger" "5.4.2"
     "@strapi/pack-up" "5.0.0"
-    "@strapi/permissions" "5.3.0"
-    "@strapi/types" "5.3.0"
-    "@strapi/typescript-utils" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/permissions" "5.4.2"
+    "@strapi/types" "5.4.2"
+    "@strapi/typescript-utils" "5.4.2"
+    "@strapi/utils" "5.4.2"
     bcryptjs "2.4.3"
     boxen "5.1.2"
     chalk "4.1.2"
@@ -1990,14 +1991,14 @@
     undici "6.19.2"
     yup "0.32.9"
 
-"@strapi/data-transfer@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/data-transfer/-/data-transfer-5.3.0.tgz#a28206b18939b51b2498d671fa92f1e34ed1a6df"
-  integrity sha512-Egvk3rGtnovoGxRBqJEWhGmPjrL7dAS8788J6rR0Md0wJHO1xwCYsiK4w4uLfdufJt5BxTgLuYv3+uKY1b4zNQ==
+"@strapi/data-transfer@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/data-transfer/-/data-transfer-5.4.2.tgz#e81ca4b41153c97184ffc89ffbfee463a1742641"
+  integrity sha512-NI8tFUxngI1KmnJrxV+DjAWBXIko6Y56s97KJfaC0aGsY/C+nQT2kb8bwbQl0kNjIBv5bAuIEn3GhqKWOPul5Q==
   dependencies:
-    "@strapi/logger" "5.3.0"
-    "@strapi/types" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/logger" "5.4.2"
+    "@strapi/types" "5.4.2"
+    "@strapi/utils" "5.4.2"
     chalk "4.1.2"
     cli-table3 "0.6.5"
     commander "8.3.0"
@@ -2013,13 +2014,13 @@
     tar-stream "2.2.0"
     ws "8.17.1"
 
-"@strapi/database@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-5.3.0.tgz#6eb11a63e03ec57f26a082db7891be4db369dc08"
-  integrity sha512-FEK+LiZm7SbNroz8THobLUlyJlxRSespF3v/83M7t5FiFDdq60tag/TaXo+kkxfJh9RdRa5OxorA7J+0IRUerw==
+"@strapi/database@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-5.4.2.tgz#e3d9fa384fcb7b833c4244980d2b6f61fef191ca"
+  integrity sha512-djMR0R638hCkG7lI0VJxLkNzT1joK8prOhDFi+LAtZpBnPUCNvd3jIu2F43HaTHsSRaifMTsRhwkyPbSoBCXeQ==
   dependencies:
     "@paralleldrive/cuid2" "2.2.2"
-    "@strapi/utils" "5.3.0"
+    "@strapi/utils" "5.4.2"
     ajv "8.16.0"
     date-fns "2.30.0"
     debug "4.3.4"
@@ -2029,7 +2030,35 @@
     semver "7.5.4"
     umzug "3.8.1"
 
-"@strapi/design-system@2.0.0-rc.12", "@strapi/design-system@^2.0.0-rc.10":
+"@strapi/design-system@2.0.0-rc.13":
+  version "2.0.0-rc.13"
+  resolved "https://registry.yarnpkg.com/@strapi/design-system/-/design-system-2.0.0-rc.13.tgz#2ecde58b4f01d4b982a974ffd2d12e852190142d"
+  integrity sha512-C0Br9VH06rnx4MzUU/knWaglRuzEjl9I/5dI4lrplPnVaOqHgr7fnOi0SOfojJRfzPLclwTO2pislU4z22O35w==
+  dependencies:
+    "@codemirror/lang-json" "6.0.1"
+    "@floating-ui/react-dom" "2.1.0"
+    "@internationalized/date" "3.5.4"
+    "@internationalized/number" "3.5.3"
+    "@radix-ui/react-accordion" "1.1.2"
+    "@radix-ui/react-alert-dialog" "1.0.5"
+    "@radix-ui/react-avatar" "1.0.4"
+    "@radix-ui/react-checkbox" "1.0.4"
+    "@radix-ui/react-dialog" "1.0.5"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-dropdown-menu" "2.0.6"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-popover" "1.0.7"
+    "@radix-ui/react-progress" "1.0.3"
+    "@radix-ui/react-radio-group" "1.1.3"
+    "@radix-ui/react-scroll-area" "1.0.5"
+    "@radix-ui/react-switch" "1.0.3"
+    "@radix-ui/react-tabs" "1.0.4"
+    "@radix-ui/react-tooltip" "1.0.7"
+    "@strapi/ui-primitives" "2.0.0-rc.13"
+    "@uiw/react-codemirror" "4.22.2"
+    react-remove-scroll "2.5.10"
+
+"@strapi/design-system@^2.0.0-rc.10":
   version "2.0.0-rc.12"
   resolved "https://registry.yarnpkg.com/@strapi/design-system/-/design-system-2.0.0-rc.12.tgz#2fa82985f36c889ad909eada7a585f66f794fef4"
   integrity sha512-xtetrMqYi4CPzKCPbx9I3RYBwWAEBTDF3rrknEmKGqpLt+0OV+nRmNA5H3425NrWDcWp01MIEMJxB5EURGCq+A==
@@ -2057,28 +2086,28 @@
     "@uiw/react-codemirror" "4.22.2"
     react-remove-scroll "2.5.10"
 
-"@strapi/email@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/email/-/email-5.3.0.tgz#7da5aa36c9d1dc44e47b8c6c2b4b860911acc6b3"
-  integrity sha512-3JgFk0+F1SpOonMS0hRPVApKlx4Kd2KJq0B47Dfog7CtNPkHls2Za4lhhcXEzvBmgGjoYJGHPmRuqNMf/rT7Ww==
+"@strapi/email@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/email/-/email-5.4.2.tgz#ebe94358813123c1f710ca8e6be0e00792e9e41a"
+  integrity sha512-zq5HPVjc+I0DpL3I+6zJzLFBDg0QxUF9+8GsXM22l2iGjNDmDkJCOl4kYHpvSOXSr5DmIj/EXtTB2D7LBH1oaw==
   dependencies:
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/provider-email-sendmail" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/provider-email-sendmail" "5.4.2"
+    "@strapi/utils" "5.4.2"
     lodash "4.17.21"
     react-intl "6.6.2"
     react-query "3.39.3"
     yup "0.32.9"
 
-"@strapi/generators@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-5.3.0.tgz#dbe47c8aaa7c909bff2cd03ff0a6e10bc1693fac"
-  integrity sha512-gH1sgE7CWkTrGYdfvbN4aPKV5YWXMRJbRMSFJ3vH/TPPRciKlsHxoOGEEqmUYLveNjmzn6XM7vi/uk65FGybHw==
+"@strapi/generators@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-5.4.2.tgz#abf0dac7c6af7e559dc83877f4c1d141bf6fe8e2"
+  integrity sha512-q+foxv9XHgMALpbWi3EUz8ijF3LD3ni8oaBgpB61Q0C7sInd3ZF4gw5r3nqi0SMrV/t8RNA3brbU3Fb5FjnuUw==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/typescript-utils" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/typescript-utils" "5.4.2"
+    "@strapi/utils" "5.4.2"
     chalk "4.1.2"
     copyfiles "2.4.1"
     fs-extra "11.2.0"
@@ -2086,30 +2115,35 @@
     plop "4.0.1"
     pluralize "8.0.0"
 
-"@strapi/i18n@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/i18n/-/i18n-5.3.0.tgz#2c5740d3442945c96108fa0325132f354d651b96"
-  integrity sha512-S3IPOBlq789VAqLiFgfM9kMOFhJrG7JnJ4+Levnf3DJbbxCAUlVeOiI+DcXn5jBDi9Jpfh4oePovoU2nRc7Axg==
+"@strapi/i18n@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/i18n/-/i18n-5.4.2.tgz#da546c8b37a1ddde822460616071011f3869cfe5"
+  integrity sha512-Mf5ZiWWq0CJhkPWYl1mn/dUr7/PunZd4D7VC+Ggbhtn1MLK07m7OVqYoYObM9WfSH9pn9ILv4W66zRuU9k9PiA==
   dependencies:
     "@reduxjs/toolkit" "1.9.7"
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/utils" "5.3.0"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/utils" "5.4.2"
     lodash "4.17.21"
     qs "6.11.1"
     react-intl "6.6.2"
     react-redux "8.1.3"
     yup "0.32.9"
 
-"@strapi/icons@2.0.0-rc.12", "@strapi/icons@^2.0.0-rc.10":
+"@strapi/icons@2.0.0-rc.13":
+  version "2.0.0-rc.13"
+  resolved "https://registry.yarnpkg.com/@strapi/icons/-/icons-2.0.0-rc.13.tgz#ec5fbe60812943b71918a07cd56c869099ab3aa1"
+  integrity sha512-z61p/LBRO/b9CNVtbbaq18LQ/ESuUBCFErd+h+2J2p+n75OSsD0baATvRCxbdCvR/WIIaYF03C5pvCp0Q5/rcA==
+
+"@strapi/icons@^2.0.0-rc.10":
   version "2.0.0-rc.12"
   resolved "https://registry.yarnpkg.com/@strapi/icons/-/icons-2.0.0-rc.12.tgz#a8d268bbf3d628b466b102877a5355113024bac6"
   integrity sha512-Qt5WQ9fjS1Xh7F8Elrlf3ACJGwCjogZ7xFHl/xZNUgAueZb7OYsVL6Aclr/xAJe8cJP5ohpB0c6FI3JoyjcnHQ==
 
-"@strapi/logger@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-5.3.0.tgz#a6c3b4b40be1caedfbd0cab161356058852bff1e"
-  integrity sha512-rAJjv6vOWcNA50/GXSeVyP6qmy/me4eie1qkWjI0ZFIY0pL6V1eahau2ZsFyASiFsBQEn9f6qp5HBqViYU5Esg==
+"@strapi/logger@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-5.4.2.tgz#51a00805c064af8496d5816a722a6ae6636924ec"
+  integrity sha512-8LPqrFX8yd64x8EASCE9KsQVA54rSFq6DejWIxiCO9veW8pEhj7cJ2L1tMAY/FQwBnKldoumIIehFnD4jZfl2g==
   dependencies:
     lodash "4.17.21"
     winston "3.10.0"
@@ -2141,24 +2175,24 @@
     vite "5.2.8"
     yup "0.32.9"
 
-"@strapi/permissions@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/permissions/-/permissions-5.3.0.tgz#850d13c246989d8c04127ce7cf6eb234bee8eb28"
-  integrity sha512-v7CBMi91z0GKsYy2hCrVqUuECjZsTbD2ZlKbwwkpW/j9M++3y8dMfQcjgAXpJxoe2XjuwK4gI4MDl4aVt8gDIg==
+"@strapi/permissions@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/permissions/-/permissions-5.4.2.tgz#25410675f89de34eadb657388c12c7a83c166798"
+  integrity sha512-9/HmNJaeGI8lJIYGsSPd7779Y5ab4fP/w76v568Yn2T8K/gBYsrZm5pv30ZfVCUUXj/LkjcU3mpR1ZxVgxw7qA==
   dependencies:
     "@casl/ability" "6.5.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/utils" "5.4.2"
     lodash "4.17.21"
     qs "6.11.1"
     sift "16.0.1"
 
-"@strapi/plugin-cloud@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-cloud/-/plugin-cloud-5.3.0.tgz#7e7eb5f19b1332fec0bb913ff328e9e2bfb3e31f"
-  integrity sha512-Y30elqf+SxYfm+XgmrfwgIUFstWVe2rkjoEO00/5P+hsMCOBwwiX1Tx0nAn9AnXQ9EsRz3VwKlQNWCbg6v9EFQ==
+"@strapi/plugin-cloud@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-cloud/-/plugin-cloud-5.4.2.tgz#a98cc6aa2286d0371b1d487c5da0cac4af35e5ec"
+  integrity sha512-0pYaxrS8NR5hfm8qB1lS8q4x5jgCQli//40EHX67mMuvaI2iOItk5aAMcvyR//naXh4LCF6Jb8yPfeBfAsfqzg==
   dependencies:
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
     react-intl "6.6.2"
 
 "@strapi/plugin-seo@^2.0.4":
@@ -2178,14 +2212,14 @@
     showdown "^2.1.0"
     styled-components "^6.0.0"
 
-"@strapi/plugin-users-permissions@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-users-permissions/-/plugin-users-permissions-5.3.0.tgz#d1b5105760baa3ac0a52f20617d705f956c2600c"
-  integrity sha512-6NBD8xOq19P3rE0MChhaiLB3LSpbm1KaUcsM8qqkkr8yfp/HGASACVCgqtn6W4VssHpaT8j5cdshE+bn+rHC3A==
+"@strapi/plugin-users-permissions@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-users-permissions/-/plugin-users-permissions-5.4.2.tgz#f31f167e2e7832dd487c49e21158db2891251701"
+  integrity sha512-mQimyAmZdIN/3oMNY0pubbfaFGet6HHPh4f8umMXyC4I6YKmQWGkIqbVCgaa45AEFpv8qPt5XCJLOq6xzYaTOA==
   dependencies:
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/utils" "5.3.0"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/utils" "5.4.2"
     bcryptjs "2.4.3"
     formik "2.4.5"
     grant-koa "5.4.8"
@@ -2203,31 +2237,31 @@
     url-join "4.0.1"
     yup "0.32.9"
 
-"@strapi/provider-email-sendmail@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-5.3.0.tgz#7a290ab5b7af7f195659592d11a976e5164f6617"
-  integrity sha512-J+M/Ze4Qn1LMzMV1Ly/vrgEzxUZoZmLurc09nBAK1hgTRIwA2mxlSv9vhs2KdYA6hNia1jsv7oKH7PGBnUvTfA==
+"@strapi/provider-email-sendmail@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-5.4.2.tgz#26232019500e83b153d2515bb40267f620aac261"
+  integrity sha512-oRujyoW1CeYGbJKfPdJSYHXfv1+QJwdfLLmN1Md4vEOBmNYl12HYwZWWuVAkS8aJnfy9X6Ju0r+6eROHabCuSg==
   dependencies:
-    "@strapi/utils" "5.3.0"
+    "@strapi/utils" "5.4.2"
     sendmail "^1.6.1"
 
-"@strapi/provider-upload-local@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-5.3.0.tgz#177f5662efb9f790e7940842d6ca3939f826bdb8"
-  integrity sha512-DNnJXHOCjIUlh3yskwujSw+OSBjK5Uocd3mrpVslAHtAf3Y1rfsLcP915+he/WKI2aX2zfY6Xx2fgv1Rshi2Cw==
+"@strapi/provider-upload-local@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-5.4.2.tgz#5f72ec5ddac241ed75ef6ef1f5294e30264b60f0"
+  integrity sha512-ywEiNeYRktZnRC97UJoJL/OTWmq6j/rZOYibIB2c2I+hDcf19PKH3RtkN+ZCfqfBxLHt6YqdMvg1egiZeFeHEA==
   dependencies:
-    "@strapi/utils" "5.3.0"
+    "@strapi/utils" "5.4.2"
     fs-extra "11.2.0"
 
-"@strapi/review-workflows@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/review-workflows/-/review-workflows-5.3.0.tgz#94321e3307294bff065e6635d954599e69ea9640"
-  integrity sha512-8ErApG7o84Q4acXM9AVaR+l6sPOh3XZMXlcPfYpT7IDMtudLJ8pM6I0X0Y4lsiiMiz+3CGCjitwUGpUPxk2yTA==
+"@strapi/review-workflows@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/review-workflows/-/review-workflows-5.4.2.tgz#ff285862d320590b39dc9bdb4fb7ffe01da27665"
+  integrity sha512-B51s78hbg1yjOQqgL3BuRl4/qXJ9uNguhcSCS9HOHR1izNm5CJirZxCNLnuc0hXGHI46e80Fd69q6H647kMd2g==
   dependencies:
     "@reduxjs/toolkit" "1.9.7"
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/utils" "5.3.0"
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/utils" "5.4.2"
     fractional-indexing "3.2.0"
     react-dnd "16.0.1"
     react-dnd-html5-backend "16.0.1"
@@ -2236,31 +2270,31 @@
     react-redux "8.1.3"
     yup "0.32.9"
 
-"@strapi/strapi@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-5.3.0.tgz#af1cec957e12f8ba3178880b58104a20a82d748e"
-  integrity sha512-f6DWn57m9B5Ocu+hbMV4ND1yBdh2H+rVms2rp8zOgnu/NcgwyTJHVv20+spv2WhkXxRA2luAqAUa+z1AnVenWQ==
+"@strapi/strapi@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-5.4.2.tgz#7f008a9ade3a142a02c9d4799a0bef3f2d140a36"
+  integrity sha512-H/J3ZHG/kGWfVh8gAcbgnKTPYZcsq2zLX8YcL2GYyxLcF3T1RiDmPXdO8v5e+72qgU5//2Tw1tRFj5HAeiO6qA==
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin" "0.5.15"
-    "@strapi/admin" "5.3.0"
-    "@strapi/cloud-cli" "5.3.0"
-    "@strapi/content-manager" "5.3.0"
-    "@strapi/content-releases" "5.3.0"
-    "@strapi/content-type-builder" "5.3.0"
-    "@strapi/core" "5.3.0"
-    "@strapi/data-transfer" "5.3.0"
-    "@strapi/database" "5.3.0"
-    "@strapi/email" "5.3.0"
-    "@strapi/generators" "5.3.0"
-    "@strapi/i18n" "5.3.0"
-    "@strapi/logger" "5.3.0"
+    "@strapi/admin" "5.4.2"
+    "@strapi/cloud-cli" "5.4.2"
+    "@strapi/content-manager" "5.4.2"
+    "@strapi/content-releases" "5.4.2"
+    "@strapi/content-type-builder" "5.4.2"
+    "@strapi/core" "5.4.2"
+    "@strapi/data-transfer" "5.4.2"
+    "@strapi/database" "5.4.2"
+    "@strapi/email" "5.4.2"
+    "@strapi/generators" "5.4.2"
+    "@strapi/i18n" "5.4.2"
+    "@strapi/logger" "5.4.2"
     "@strapi/pack-up" "5.0.0"
-    "@strapi/permissions" "5.3.0"
-    "@strapi/review-workflows" "5.3.0"
-    "@strapi/types" "5.3.0"
-    "@strapi/typescript-utils" "5.3.0"
-    "@strapi/upload" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/permissions" "5.4.2"
+    "@strapi/review-workflows" "5.4.2"
+    "@strapi/types" "5.4.2"
+    "@strapi/typescript-utils" "5.4.2"
+    "@strapi/upload" "5.4.2"
+    "@strapi/utils" "5.4.2"
     "@types/nodemon" "1.19.6"
     "@vitejs/plugin-react-swc" "3.6.0"
     boxen "5.1.2"
@@ -2307,18 +2341,18 @@
     yalc "1.0.0-pre.53"
     yup "0.32.9"
 
-"@strapi/types@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/types/-/types-5.3.0.tgz#dbed98ce30ff326b58bb8d4a5d6ad553b82a5e19"
-  integrity sha512-r/u0x/Iu6t+TI63byCsCp2+XBz+xUOZX2T6gLP14N+z64TTlXL9IDnE09L6EYho+yYuRGOaUdJk3cy0XP987Dw==
+"@strapi/types@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/types/-/types-5.4.2.tgz#1c779df0c0b12e01f0df8513e9a79c21e16e63cf"
+  integrity sha512-J2msX4Z9FLDMB8heMDrW3xea/RT6Jdvdc2zexX64Bc9eVriNQX/6S+LKl9khSCs4Qm91u17wOyMr3XvNsKAOjg==
   dependencies:
     "@casl/ability" "6.5.0"
     "@koa/cors" "5.0.0"
     "@koa/router" "12.0.2"
-    "@strapi/database" "5.3.0"
-    "@strapi/logger" "5.3.0"
-    "@strapi/permissions" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@strapi/database" "5.4.2"
+    "@strapi/logger" "5.4.2"
+    "@strapi/permissions" "5.4.2"
+    "@strapi/utils" "5.4.2"
     commander "8.3.0"
     koa "2.15.2"
     koa-body "6.0.1"
@@ -2327,10 +2361,10 @@
     typedoc-github-wiki-theme "1.1.0"
     typedoc-plugin-markdown "3.17.1"
 
-"@strapi/typescript-utils@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/typescript-utils/-/typescript-utils-5.3.0.tgz#541ea9084888b2abb39b39d27cdf71760fbd941f"
-  integrity sha512-hXIKjLEb3n6K75E8epwmOHg7Al8e97SdCf3o/wKZdDRHDTmTcdnSlO94fIrfJywGpc2QxjfkTdL91oBCI0sEaw==
+"@strapi/typescript-utils@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/typescript-utils/-/typescript-utils-5.4.2.tgz#8087c43c00f41e5e8d1a254ae746bc990452b50f"
+  integrity sha512-jo5LgqqpJDELMmLcdCP6QGWdHKkEMRBHecjHkSgqPHcdE7nGi+2jsJabx9CTGTcDb/w+3KmiUuYYuOaQJ3TbUA==
   dependencies:
     chalk "4.1.2"
     cli-table3 "0.6.5"
@@ -2366,15 +2400,42 @@
     aria-hidden "1.2.4"
     react-remove-scroll "2.5.10"
 
-"@strapi/upload@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/upload/-/upload-5.3.0.tgz#f2a432a03f691a61fcc0c3628dd3fb9723dee63c"
-  integrity sha512-gxW8yDzwuJttqVE1gmPb7DVawQq7+b9dCFa3uV34qcpwn+COmwmGa7nBPy/LphB5XGNCo+TC1QKcpEa3qbP7WQ==
+"@strapi/ui-primitives@2.0.0-rc.13":
+  version "2.0.0-rc.13"
+  resolved "https://registry.yarnpkg.com/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.13.tgz#1deebe31a26b4419ce65506413bd25463653e3c6"
+  integrity sha512-yOkuC7ci5MZcdMDGWlq4tZbvx4sJmxiSYmIQpDV1P5jCerGzDpn5l/b3JS4bqixvSN2ZdeUsKYraaSRzUTtFdQ==
   dependencies:
-    "@strapi/design-system" "2.0.0-rc.12"
-    "@strapi/icons" "2.0.0-rc.12"
-    "@strapi/provider-upload-local" "5.3.0"
-    "@strapi/utils" "5.3.0"
+    "@radix-ui/number" "1.0.1"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+    aria-hidden "1.2.4"
+    react-remove-scroll "2.5.10"
+
+"@strapi/upload@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/upload/-/upload-5.4.2.tgz#1945a45bce58dcc3de8051511e0e4cd823abadd2"
+  integrity sha512-LrXF+LIA0jIlCbqPfZIxzBWoL4LWMpUxs3tOckdwe0HwbZ+VtZcHse8cLDawe/53qHlGYUsO2Vs7qNO0se8THw==
+  dependencies:
+    "@strapi/design-system" "2.0.0-rc.13"
+    "@strapi/icons" "2.0.0-rc.13"
+    "@strapi/provider-upload-local" "5.4.2"
+    "@strapi/utils" "5.4.2"
     byte-size "8.1.1"
     cropperjs "1.6.1"
     date-fns "2.30.0"
@@ -2395,10 +2456,10 @@
     sharp "0.32.6"
     yup "0.32.9"
 
-"@strapi/utils@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-5.3.0.tgz#cbbb9859443dc8a6db60473a728ca3c67ad286c0"
-  integrity sha512-suX1dP3T9fD9b8rdNR3//jMeuugO62IHYambpDjpbtK/RgyzIudGpyBOUk/LNSgSlAAPC2k9Fws+GqBeLEpzLA==
+"@strapi/utils@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-5.4.2.tgz#01d3493dee0d8e07af253ace89c9e4b214a89063"
+  integrity sha512-K36/J4B9RzwP3ExutKFaUGbi4pyvXOQ/YNgr0Hv7QMH7vxFu9Z2tLlM725Ao77FbQhFlsRh5v1KVAbXF3TYA9w==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
     date-fns "2.30.0"


### PR DESCRIPTION
### What does it do?

Upgrades to 5.4.2 to potentially fix a loading issue for the hosted demos

### Why is it needed?

Because.

### How to test it?

Simply make sure the whole Strapi application doesn't crash and the connected Next.js application is fully working.

Some additional things to check:

- [x] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
