### PR TITLE
fix: missing locale props

### DIFF
--- a/next/components/navbar/mobile-navbar.tsx
+++ b/next/components/navbar/mobile-navbar.tsx
@@ -59,7 +59,7 @@ export const MobileNavbar = ({ leftNavbarItems, rightNavbarItems, logo, locale }
           <div className="flex items-center justify-between w-full px-5">
             <Logo locale={locale} image={logo?.image} />
             <div className="flex items-center space-x-2">
-              <LocaleSwitcher />
+              <LocaleSwitcher currentLocale={locale} />
               <IoIosClose
                 className="h-8 w-8 text-white"
                 onClick={() => setOpen(!open)}


### PR DESCRIPTION
add missing props in LocaleSwitcher

### What does it do?

This change adds the missing props to the LocaleSwitcher component.
Though it's a simple fix, I plan to continue exploring this project by creating various apps and addressing bugs along the way.

``` JSX
<LocaleSwitcher currentLocale={locale} />
```

### Why is it needed?

The missing props are required by the type definitions, and their absence causes type-checking errors during the build process.

### How to test it?
I successfully built the app without errors.

![image](https://github.com/user-attachments/assets/c26f8307-73ae-4fde-9aa6-aff4fee87451)
Additionally, I tested it in the development environment using yarn dev.

Some additional things to check:

This is a minor change, and while I did not conduct a thorough verification, I confirmed like UUID generation as part of the review.

- [ ] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
- [ ] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.
- [ ] Strapi version is the latest possible.

### Related issue(s)/PR(s)
I created and resolved this issue.
#27 