### PR TITLE
[ PR TO FIX ISSUE # 41 ] Update the seed file to conform with Postgres validation and updated article schema file.

### DIFF
--- a/strapi/src/api/article/content-types/article/schema.json
+++ b/strapi/src/api/article/content-types/article/schema.json
@@ -40,7 +40,7 @@
           "localized": true
         }
       },
-      "type": "string"
+      "type": "text"
     },
     "slug": {
       "pluginOptions": {

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -399,7 +399,7 @@ export interface ApiArticleArticle extends Struct.CollectionTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    description: Schema.Attribute.String &
+    description: Schema.Attribute.Text &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;


### PR DESCRIPTION
### What does it do?

This PR fixes the issue described in [this GitHub issue](https://github.com/strapi/LaunchPad/issues/41), where the seed file import would fail when switching to a Postgres database.

### Why is it needed?

When switching to Postgres, the seed import process was breaking. This fix ensures the import works correctly and prevents the app from crashing.

### How to test it?

1. Clone the repo.
2. Run yarn setup in the root directory to install all dependencies.
3. Install the Postgres driver: `yarn add pg`
4. Make sure a local Postgres instance is running.

Update your .env file with the correct database credentials.

Here’s an example `.env` file setup:

```
HOST=0.0.0.0
PORT=1337
APP_KEYS="toBeModified1,toBeModified2"
API_TOKEN_SALT=tobemodified
ADMIN_JWT_SECRET=tobemodified
TRANSFER_TOKEN_SALT=tobemodified
JWT_SECRET=tobemodified

STRAPI_ADMIN_CLIENT_URL=http://localhost:3000
STRAPI_ADMIN_CLIENT_PREVIEW_SECRET=a-random-token

CLIENT_URL=http://localhost:3000
PREVIEW_SECRET=your-secret-key # optional, required with Next.js draft mode

# Database Configuration
DATABASE_CLIENT=postgres
DATABASE_HOST=localhost
DATABASE_PORT=5432
DATABASE_NAME=your-database-name
DATABASE_USERNAME=postgres
DATABASE_PASSWORD=your-password
DATABASE_SSL=false

# Optional Database Settings
DATABASE_SCHEMA=public
DATABASE_POOL_MIN=2
DATABASE_POOL_MAX=10

# Optional SSL Configuration (if needed)
# DATABASE_SSL_KEY=
# DATABASE_SSL_CERT=
# DATABASE_SSL_CA=
# DATABASE_SSL_CAPATH=
# DATABASE_SSL_CIPHER=
# DATABASE_SSL_REJECT_UNAUTHORIZED=true
```

Once the database is running and connected, run:

```
  yarn seed
```

This will import all the seed data. If everything is working correctly, the import should complete without errors. 
Some additional things to check:

### Related issue(s)/PR(s)
[this GitHub issue](https://github.com/strapi/LaunchPad/issues/41)

Let us know if this is related to any issue/pull request.