### PR TITLE
fix: updated schema to avoid DTS issue

### DIFF
--- a/strapi/src/components/shared/seo.json
+++ b/strapi/src/components/shared/seo.json
@@ -2,7 +2,8 @@
   "collectionName": "components_shared_seos",
   "info": {
     "displayName": "seo",
-    "icon": "search"
+    "icon": "search",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -12,7 +13,7 @@
       "maxLength": 60
     },
     "metaDescription": {
-      "type": "string",
+      "type": "text",
       "required": true,
       "minLength": 50
     },

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -441,13 +441,14 @@ export interface SharedSection extends Struct.ComponentSchema {
 export interface SharedSeo extends Struct.ComponentSchema {
   collectionName: 'components_shared_seos';
   info: {
+    description: '';
     displayName: 'seo';
     icon: 'search';
   };
   attributes: {
     canonicalURL: Schema.Attribute.String;
     keywords: Schema.Attribute.Text;
-    metaDescription: Schema.Attribute.String &
+    metaDescription: Schema.Attribute.Text &
       Schema.Attribute.Required &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 50;


### PR DESCRIPTION
### What does it do?

Changed the metaDescription field from the SEO component from `Short text` to `Long text`

### Why is it needed?

Avoid a clash when seeding data, where one of the French translation is longer than the 255 characters maximum count for Short text 

### How to test it?

Simply make sure the whole Strapi application doesn't crash and the connected Next.js application is fully working.

Some additional things to check:

- [X] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
- [ ] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.
- [X] Strapi version is the latest possible.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request.