### PR TITLE
chore: fix prefill login script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,9 @@ Simply make sure the whole Strapi application doesn't crash and the connected Ne
 Some additional things to check:
 
 - [ ] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
-- [ ] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.
 - [ ] Strapi version is the latest possible.
+- [ ] If the Strapi version has been changed, make sure that the `strapi/scripts/prefillLoginFields.js` works.
+- [ ] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.
 
 ### Related issue(s)/PR(s)
 

--- a/strapi/scripts/prefillLoginFields.js
+++ b/strapi/scripts/prefillLoginFields.js
@@ -8,23 +8,31 @@ const directoryPath =
 const targetFiles = ["Login.js", "Login.mjs"]; // You can add more file patterns here
 
 // Content to replace
-const originalContent = `initialVf halues: {
+const originalContent = `initialValues: {
                                 email: '',
                                 password: '',
                                 rememberMe: false
                             },`;
 
 const newContent = `initialValues: {
-                            email: "admin@strapidemo.com",
-                            password: "welcomeToStrapi123",
-                            rememberMe: false
-                        },`;
+                                email: "admin@strapidemo.com",
+                                password: "welcomeToStrapi123",
+                                rememberMe: false
+                            },`;
 
 // Function to update a given file
 const updateFile = (filePath) => {
   fs.readFile(filePath, "utf8", (err, data) => {
     if (err) {
       console.error(`❌ Error reading file ${filePath}:`, err);
+      return;
+    }
+
+    if (data.includes(newContent)) {
+      console.log(`✅ File already modified with demo credentials: ${filePath}`);
+      console.log('Current credentials:');
+      console.log('  Email:', newContent.match(/email:\s*"([^"]+)"/)[1]);
+      console.log('  Password:', newContent.match(/password:\s*"([^"]+)"/)[1]);
       return;
     }
 
@@ -37,6 +45,9 @@ const updateFile = (filePath) => {
           return;
         }
         console.log(`✅ Successfully updated: ${filePath}`);
+        console.log('Updated credentials:');
+        console.log('  Email:', newContent.match(/email:\s*"([^"]+)"/)[1]);
+        console.log('  Password:', newContent.match(/password:\s*"([^"]+)"/)[1]);
       });
     } else {
       console.log(`⚠️ Original content not found in: ${filePath}`);

--- a/strapi/scripts/prefillLoginFields.js
+++ b/strapi/scripts/prefillLoginFields.js
@@ -8,7 +8,7 @@ const directoryPath =
 const targetFiles = ["Login.js", "Login.mjs"]; // You can add more file patterns here
 
 // Content to replace
-const originalContent = `initialValues: {
+const originalContent = `initialVf halues: {
                                 email: '',
                                 password: '',
                                 rememberMe: false
@@ -56,6 +56,7 @@ targetFiles.forEach((pattern) => {
       files.forEach(updateFile);
     } else {
       console.log(`⚠️ No matching files found for: ${pattern}`);
+      process.exit(1);
     }
   });
 });

--- a/strapi/scripts/prefillLoginFields.js
+++ b/strapi/scripts/prefillLoginFields.js
@@ -30,9 +30,6 @@ const updateFile = (filePath) => {
 
     if (data.includes(newContent)) {
       console.log(`✅ File already modified with demo credentials: ${filePath}`);
-      console.log('Current credentials:');
-      console.log('  Email:', newContent.match(/email:\s*"([^"]+)"/)[1]);
-      console.log('  Password:', newContent.match(/password:\s*"([^"]+)"/)[1]);
       return;
     }
 
@@ -45,9 +42,6 @@ const updateFile = (filePath) => {
           return;
         }
         console.log(`✅ Successfully updated: ${filePath}`);
-        console.log('Updated credentials:');
-        console.log('  Email:', newContent.match(/email:\s*"([^"]+)"/)[1]);
-        console.log('  Password:', newContent.match(/password:\s*"([^"]+)"/)[1]);
       });
     } else {
       console.log(`⚠️ Original content not found in: ${filePath}`);

--- a/strapi/scripts/prefillLoginFields.js
+++ b/strapi/scripts/prefillLoginFields.js
@@ -2,62 +2,60 @@ const fs = require("fs");
 const path = require("path");
 const glob = require("glob");
 
-// Specify the directory path and the pattern to find the file
-const directoryPath = "./node_modules/@strapi/admin/dist/admin/";
-const filePattern = "index-*.mjs";
+// Base directory and target file patterns
+const directoryPath =
+  "./node_modules/@strapi/admin/dist/admin/admin/src/pages/Auth/components";
+const targetFiles = ["Login.js", "Login.mjs"]; // You can add more file patterns here
 
-// Function to find and replace the specific content in the file
+// Content to replace
+const originalContent = `initialValues: {
+                                email: '',
+                                password: '',
+                                rememberMe: false
+                            },`;
+
+const newContent = `initialValues: {
+                            email: "admin@strapidemo.com",
+                            password: "welcomeToStrapi123",
+                            rememberMe: false
+                        },`;
+
+// Function to update a given file
 const updateFile = (filePath) => {
-  // Read the file content
   fs.readFile(filePath, "utf8", (err, data) => {
     if (err) {
-      console.error(`Error reading file ${filePath}:`, err);
+      console.error(`❌ Error reading file ${filePath}:`, err);
       return;
     }
 
-    // Define the original and replacement content
-    const originalContent = `initialValues: {
-            email: "",
-            password: "",
-            rememberMe: false
-          },`;
-
-    const newContent = `initialValues: {
-            email: "admin@strapidemo.com",
-            password: "welcomeToStrapi123",
-            rememberMe: false
-          },`;
-
-    // Check if the content exists and replace it
     if (data.includes(originalContent)) {
       const updatedData = data.replace(originalContent, newContent);
 
-      // Write the updated content back to the file
       fs.writeFile(filePath, updatedData, "utf8", (err) => {
         if (err) {
-          console.error(`Error writing to file ${filePath}:`, err);
+          console.error(`❌ Error writing to file ${filePath}:`, err);
           return;
         }
-        console.log(`Successfully updated the content in file: ${filePath}`);
+        console.log(`✅ Successfully updated: ${filePath}`);
       });
     } else {
-      console.log(`Original content not found in file: ${filePath}`);
+      console.log(`⚠️ Original content not found in: ${filePath}`);
     }
   });
 };
 
-// Find the file using glob pattern matching
-glob(path.join(directoryPath, filePattern), (err, files) => {
-  if (err) {
-    console.error("Error finding files:", err);
-    return;
-  }
+// Iterate over each file pattern
+targetFiles.forEach((pattern) => {
+  glob(path.join(directoryPath, pattern), (err, files) => {
+    if (err) {
+      console.error("❌ Error finding files:", err);
+      return;
+    }
 
-  // Process the first file found (since index-*.mjs may match multiple files)
-  if (files.length > 0) {
-    const filePath = files[0];
-    updateFile(filePath);
-  } else {
-    console.log("No matching files found.");
-  }
+    if (files.length > 0) {
+      files.forEach(updateFile);
+    } else {
+      console.log(`⚠️ No matching files found for: ${pattern}`);
+    }
+  });
 });


### PR DESCRIPTION
### What does it do?

Update the prefill login script for hosted demos since the new version of Strapi creates different files.

### How to test it?

- yarn install
- node ./strapi/scripts/prefillLoginFields.js
- yarn build
- yarn develop

The login form should be filled with the hosted demo credentials.



Some additional things to check:

- [x] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
- [x] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.
- [x] Strapi version is the latest possible.