### PR TITLE
 refactor: replace persistent draft mode cookies with URL parameters

### DIFF
--- a/next/app/[locale]/(marketing)/blog/[slug]/page.tsx
+++ b/next/app/[locale]/(marketing)/blog/[slug]/page.tsx
@@ -7,8 +7,14 @@ import fetchContentType from '@/lib/strapi/fetchContentType';
 
 export default async function SingleArticlePage(props: {
   params: Promise<{ slug: string; locale: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const params = await props.params;
+  const searchParams = await props.searchParams;
+
+  // Check if draft mode is enabled
+  const isDraftMode = searchParams.draft === 'true';
+
   const article = await fetchContentType(
     'articles',
     {
@@ -17,7 +23,8 @@ export default async function SingleArticlePage(props: {
         locale: params.locale,
       },
     },
-    true
+    true,
+    isDraftMode
   );
 
   if (!article) {

--- a/next/app/[locale]/(marketing)/page.tsx
+++ b/next/app/[locale]/(marketing)/page.tsx
@@ -29,8 +29,13 @@ export async function generateMetadata(props: {
 
 export default async function HomePage(props: {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const params = await props.params;
+  const searchParams = await props.searchParams;
+
+  // Check if draft mode is enabled
+  const isDraftMode = searchParams.draft === 'true';
 
   const pageData = await fetchContentType(
     'pages',
@@ -40,7 +45,8 @@ export default async function HomePage(props: {
         locale: params.locale,
       },
     },
-    true
+    true,
+    isDraftMode
   );
 
   const localizedSlugs = pageData.localizations?.reduce(

--- a/next/app/api/preview/route.ts
+++ b/next/app/api/preview/route.ts
@@ -1,4 +1,3 @@
-import { draftMode } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 export const GET = async (request: Request) => {
@@ -13,15 +12,16 @@ export const GET = async (request: Request) => {
     return new Response('Invalid token', { status: 401 });
   }
 
-  const draft = await draftMode();
+  // Instead of using cookies, pass the status as a query parameter
+  const redirectUrl = new URL(url, request.url);
 
-  if (status === 'published') {
-    // Make sure draft mode is disabled so we only query published content
-    draft.disable();
+  if (status === 'draft') {
+    redirectUrl.searchParams.set('draft', 'true');
   } else {
-    // Enable draft mode so we can query draft content
-    draft.enable();
+    // For published content, don't add any parameter (clean URL)
+    redirectUrl.searchParams.delete('draft');
   }
 
-  redirect(url);
+  redirect(redirectUrl.toString());
 };
+

--- a/next/lib/strapi/fetchContentType.ts
+++ b/next/lib/strapi/fetchContentType.ts
@@ -1,4 +1,3 @@
-import { draftMode } from 'next/headers';
 import qs from 'qs';
 
 /**
@@ -6,6 +5,8 @@ import qs from 'qs';
  *
  * @param {string} contentType - The type of content to fetch from Strapi.
  * @param {string} params - Query parameters to append to the API request.
+ * @param {boolean} spreadData - Whether to spread the data
+ * @param {boolean} isDraftMode - Whether to fetch draft or published content
  * @return {Promise<object>} The fetched data.
  */
 
@@ -31,16 +32,14 @@ export function spreadStrapiData(data: StrapiResponse): StrapiData | null {
 export default async function fetchContentType(
   contentType: string,
   params: Record<string, unknown> = {},
-  spreadData?: boolean
+  spreadData?: boolean,
+  isDraftMode: boolean = false
 ): Promise<any> {
-  const { isEnabled: isDraftMode } = await draftMode();
-
   try {
     const queryParams = { ...params };
 
-    if (isDraftMode) {
-      queryParams.status = 'draft';
-    }
+    // Set status based on draft mode parameter
+    queryParams.status = isDraftMode ? 'draft' : 'published';
 
     // Construct the full URL for the API request
     const url = new URL(`api/${contentType}`, process.env.NEXT_PUBLIC_API_URL);

--- a/strapi/config/admin.ts
+++ b/strapi/config/admin.ts
@@ -56,11 +56,14 @@ export default ({ env }) => {
             return null;
           }
 
+          // Normalize status for consistent handling
+          const normalizedStatus = status === 'draft' ? 'draft' : 'published';
+
           // Use Next.js draft mode
           const urlSearchParams = new URLSearchParams({
             url: `/${locale ?? 'en'}${pathname}`,
             secret: previewSecret,
-            status,
+            status: normalizedStatus,
           });
 
           return `${clientUrl}/api/preview?${urlSearchParams}`;

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -107,6 +107,43 @@ export interface AdminApiTokenPermission extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface AdminAuditLog extends Struct.CollectionTypeSchema {
+  collectionName: 'strapi_audit_logs';
+  info: {
+    displayName: 'Audit Log';
+    pluralName: 'audit-logs';
+    singularName: 'audit-log';
+  };
+  options: {
+    draftAndPublish: false;
+    timestamps: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Schema.Attribute.String & Schema.Attribute.Required;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    date: Schema.Attribute.DateTime & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'admin::audit-log'> &
+      Schema.Attribute.Private;
+    payload: Schema.Attribute.JSON;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    user: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+  };
+}
+
 export interface AdminPermission extends Struct.CollectionTypeSchema {
   collectionName: 'admin_permissions';
   info: {
@@ -441,6 +478,11 @@ export interface ApiArticleArticle extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     title: Schema.Attribute.String &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
@@ -512,6 +554,11 @@ export interface ApiBlogPageBlogPage extends Struct.SingleTypeSchema {
           localized: true;
         };
       }>;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     sub_heading: Schema.Attribute.String &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
@@ -549,6 +596,11 @@ export interface ApiCategoryCategory extends Struct.CollectionTypeSchema {
     name: Schema.Attribute.String;
     product: Schema.Attribute.Relation<'manyToOne', 'api::product.product'>;
     publishedAt: Schema.Attribute.DateTime;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -590,6 +642,11 @@ export interface ApiFaqFaq extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -637,6 +694,11 @@ export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
           localized: true;
         };
       }>;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -664,6 +726,11 @@ export interface ApiLogoLogo extends Struct.CollectionTypeSchema {
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::logo.logo'> &
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -726,6 +793,11 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         };
       }> &
       Schema.Attribute.DefaultTo<'slug'>;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -758,6 +830,11 @@ export interface ApiPlanPlan extends Struct.CollectionTypeSchema {
     price: Schema.Attribute.Integer;
     product: Schema.Attribute.Relation<'manyToOne', 'api::product.product'>;
     publishedAt: Schema.Attribute.DateTime;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     sub_text: Schema.Attribute.String;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
@@ -823,6 +900,11 @@ export interface ApiProductPageProductPage extends Struct.SingleTypeSchema {
           localized: true;
         };
       }>;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     sub_heading: Schema.Attribute.String &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
@@ -872,6 +954,11 @@ export interface ApiProductProduct extends Struct.CollectionTypeSchema {
     price: Schema.Attribute.Integer;
     publishedAt: Schema.Attribute.DateTime;
     slug: Schema.Attribute.UID<'name'>;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -901,6 +988,11 @@ export interface ApiRedirectionRedirection extends Struct.CollectionTypeSchema {
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     source: Schema.Attribute.String;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -933,6 +1025,11 @@ export interface ApiTestimonialTestimonial extends Struct.CollectionTypeSchema {
       'api::testimonial.testimonial'
     >;
     publishedAt: Schema.Attribute.DateTime;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     text: Schema.Attribute.String &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
@@ -1438,6 +1535,11 @@ export interface PluginUsersPermissionsUser
       'manyToOne',
       'plugin::users-permissions.role'
     >;
+    strapi_assignee: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
+    strapi_stage: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::review-workflows.workflow-stage'
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1455,6 +1557,7 @@ declare module '@strapi/strapi' {
     export interface ContentTypeSchemas {
       'admin::api-token': AdminApiToken;
       'admin::api-token-permission': AdminApiTokenPermission;
+      'admin::audit-log': AdminAuditLog;
       'admin::permission': AdminPermission;
       'admin::role': AdminRole;
       'admin::transfer-token': AdminTransferToken;


### PR DESCRIPTION
  - Remove Next.js draftMode() cookies that persisted across sessions
  - Implement query parameter approach (?draft=true) for draft preview
  - Update fetchContentType to accept explicit isDraftMode parameter
  - Add searchParams handling to page components for draft detection
  - Remove unnecessary middleware, exit-preview, and draft status APIs

  Fixes issue where draft content would persist on live site after preview.
  Draft mode now only active when ?draft=true is present in URL, ensuring
  clean separation between draft preview and published content.

 This explains:
  - What changed: From cookies to URL parameters
  - Why: Persistent cookies were showing draft content on live site
  - How: Query parameter approach with explicit draft detection
  - Benefit: Clean separation between draft and published content

### What does it do?

Addresses the following bug https://github.com/strapi/LaunchPad/issues/76

### Why is it needed?

Fixes preview 

### How to test it?

Pull the code, create draft, it should now not display draft state in deployed site.

Simply make sure the whole Strapi application doesn't crash and the connected Next.js application is fully working.

Some additional things to check:

- [ ] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
- [ ] Strapi version is the latest possible.
- [ ] If the Strapi version has been changed, make sure that the `strapi/scripts/prefillLoginFields.js` works.
- [ ] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request.
