### PR TITLE
copy custom admin config to prod env for cloud

### DIFF
--- a/strapi/config/env/production/admin.ts
+++ b/strapi/config/env/production/admin.ts
@@ -1,0 +1,71 @@
+const getPreviewPathname = (uid, { locale, document }): string | null => {
+  const { slug } = document;
+
+  switch (uid) {
+    case 'api::page.page': {
+      if (slug === 'homepage') {
+        return '/';
+      }
+      return `/${slug}`;
+    }
+    case 'api::product.product':
+      return `/products/${slug}`;
+    case 'api::product-page.product-page':
+      return '/products';
+    case 'api::article.article':
+      return `/blog/${slug}`;
+    case 'api::blog-page.blog-page':
+      return '/blog';
+    default:
+      return null;
+  }
+};
+
+export default ({ env }) => {
+  const clientUrl = env('CLIENT_URL');
+  const previewSecret = env('PREVIEW_SECRET');
+
+  return {
+    auth: {
+      secret: env('ADMIN_JWT_SECRET'),
+    },
+    apiToken: {
+      salt: env('API_TOKEN_SALT'),
+    },
+    transfer: {
+      token: {
+        salt: env('TRANSFER_TOKEN_SALT'),
+      },
+    },
+    flags: {
+      nps: env.bool('FLAG_NPS', true),
+      promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    },
+    preview: {
+      enabled: true,
+      config: {
+        allowedOrigins: [clientUrl],
+        async handler(uid, { documentId, locale, status }) {
+          const document = await strapi
+            .documents(uid)
+            .findOne({ documentId, locale, status });
+          const pathname = getPreviewPathname(uid, { locale, document });
+
+          // Disable preview if the pathname is not found
+          if (!pathname) {
+            return null;
+          }
+
+          // Use Next.js draft mode
+          const urlSearchParams = new URLSearchParams({
+            url: `/${locale ?? 'en'}${pathname}`,
+            secret: previewSecret,
+            status,
+          });
+
+          return `${clientUrl}/api/preview?${urlSearchParams}`;
+        },
+      },
+    },
+  };
+};


### PR DESCRIPTION
### What does it do?

Copies the modified admin config into the prod env dir structure so that cloud doesn't wipe it when it adds in some config

### Why is it needed?

Makes launchpad work on Strapi Cloud with preview options

### How to test it?

deploy it to cloud

Some additional things to check:

- [x] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
- [ ] Strapi version is the latest possible.
- [ ] If the Strapi version has been changed, make sure that the `strapi/scripts/prefillLoginFields.js` works.
- [ ] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.

### Related issue(s)/PR(s)

N/A
