### PR TITLE
fix: Address hydration warnings, hide draft mode banner within iframes, and update Strapi dependencies.

### DIFF
--- a/next/components/draft-mode-banner.tsx
+++ b/next/components/draft-mode-banner.tsx
@@ -1,12 +1,17 @@
 'use client';
 
 import { usePathname, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export function DraftModeBanner() {
   const router = useRouter();
   const pathname = usePathname();
   const [isExiting, setIsExiting] = useState(false);
+  const [isIframe, setIsIframe] = useState(true);
+
+  useEffect(() => {
+    setIsIframe(window !== window.top);
+  }, []);
 
   const handleExitDraft = async () => {
     setIsExiting(true);
@@ -18,6 +23,10 @@ export function DraftModeBanner() {
       setIsExiting(false);
     }
   };
+
+  if (isIframe) {
+    return null;
+  }
 
   return (
     <div className="fixed bottom-4 right-4 z-50 bg-secondary text-black px-6 py-3 rounded-lg shadow-lg flex items-center gap-4">

--- a/next/components/elements/button.tsx
+++ b/next/components/elements/button.tsx
@@ -40,6 +40,7 @@ export const Button: React.FC<ButtonProps> = ({
         className
       )}
       {...props}
+      suppressHydrationWarning
     >
       {children ?? `Get Started`}
     </Element>

--- a/next/components/navbar/mobile-navbar.tsx
+++ b/next/components/navbar/mobile-navbar.tsx
@@ -84,6 +84,7 @@ export const MobileNavbar = ({
                         href={`/${locale}${childNavItem.URL}`}
                         onClick={() => setOpen(false)}
                         className="relative max-w-[15rem] text-left text-2xl"
+                        suppressHydrationWarning
                       >
                         <span className="block text-white">
                           {childNavItem.text}
@@ -97,6 +98,7 @@ export const MobileNavbar = ({
                     href={`/${locale}${navItem.URL}`}
                     onClick={() => setOpen(false)}
                     className="relative"
+                    suppressHydrationWarning
                   >
                     <span className="block text-[26px] text-white">
                       {navItem.text}

--- a/next/components/navbar/navbar-item.tsx
+++ b/next/components/navbar/navbar-item.tsx
@@ -32,6 +32,7 @@ export function NavbarItem({
         className
       )}
       target={target}
+      suppressHydrationWarning
     >
       {children}
     </Link>

--- a/strapi/package.json
+++ b/strapi/package.json
@@ -20,10 +20,10 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@strapi/plugin-cloud": "5.36.1",
+    "@strapi/plugin-cloud": "5.37.0",
     "@strapi/plugin-seo": "^2.0.4",
-    "@strapi/plugin-users-permissions": "5.36.1",
-    "@strapi/strapi": "5.36.1",
+    "@strapi/plugin-users-permissions": "5.37.0",
+    "@strapi/strapi": "5.37.0",
     "better-sqlite3": "11.7.0",
     "pluralize": "^8.0.0",
     "react": "^18.0.0",

--- a/strapi/yarn.lock
+++ b/strapi/yarn.lock
@@ -2374,38 +2374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:1.1.15":
-  version: 1.1.15
-  resolution: "@radix-ui/react-dialog@npm:1.1.15"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-focus-guards": "npm:1.1.3"
-    "@radix-ui/react-focus-scope": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    aria-hidden: "npm:^1.2.4"
-    react-remove-scroll: "npm:^2.6.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/2f2c88e3c281acaea2fd9b96fa82132d59177d3aa5da2e7c045596fd4028e84e44ac52ac28f4f236910605dd7d9338c2858ba44a9ced2af2e3e523abbfd33014
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-direction@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-direction@npm:1.0.1"
@@ -2458,29 +2426,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dismissable-layer@npm:1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.11"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-escape-keydown": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c825572a64073c4d3853702029979f6658770ffd6a98eabc4984e1dee1b226b4078a2a4dc7003f96475b438985e9b21a58e75f51db74dd06848dcae1f2d395dc
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-dropdown-menu@npm:2.0.6":
   version: 2.0.6
   resolution: "@radix-ui/react-dropdown-menu@npm:2.0.6"
@@ -2522,19 +2467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-focus-guards@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@radix-ui/react-focus-guards@npm:1.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/0bab65eb8d7e4f72f685d63de7fbba2450e3cb15ad6a20a16b42195e9d335c576356f5a47cb58d1ffc115393e46d7b14b12c5d4b10029b0ec090861255866985
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-focus-scope@npm:1.0.4":
   version: 1.0.4
   resolution: "@radix-ui/react-focus-scope@npm:1.0.4"
@@ -2554,27 +2486,6 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/2fce0bafcab4e16cf4ed7560bda40654223f3d0add6b231e1c607433030c14e6249818b444b7b58ee7a6ff6bbf8e192c9c81d22c3a5c88c2daade9d1f881b5be
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-scope@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-focus-scope@npm:1.1.7"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/8a6071331bdeeb79b223463de75caf759b8ad19339cab838e537b8dbb2db236891a1f4df252445c854d375d43d9d315dfcce0a6b01553a2984ec372bb8f1300e
   languageName: node
   linkType: hard
 
@@ -2729,26 +2640,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-portal@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-portal@npm:1.1.9"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/45b432497c722720c72c493a29ef6085bc84b50eafe79d48b45c553121b63e94f9cdb77a3a74b9c49126f8feb3feee009fe400d48b7759d3552396356b192cd7
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-presence@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-presence@npm:1.0.1"
@@ -2767,26 +2658,6 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/90780618b265fe794a8f1ddaa5bfd3c71a1127fa79330a14d32722e6265b44452a9dd36efe4e769129d33e57f979f6b8713e2cbf2e2755326aa3b0f337185b6e
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-presence@npm:1.1.5":
-  version: 1.1.5
-  resolution: "@radix-ui/react-presence@npm:1.1.5"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/d0e61d314250eeaef5369983cb790701d667f51734bafd98cf759072755562018052c594e6cdc5389789f4543cb0a4d98f03ff4e8f37338d6b5bf51a1700c1d1
   languageName: node
   linkType: hard
 
@@ -3308,21 +3179,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-use-escape-keydown@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.1"
-  dependencies:
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/bff53be99e940fef1d3c4df7d560e1d9133182e5a98336255d3063327d1d3dd4ec54a95dc5afe15cca4fb6c184f0a956c70de2815578c318cf995a7f9beabaa1
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-use-layout-effect@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-use-layout-effect@npm:1.0.1"
@@ -3718,9 +3574,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/admin@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/admin@npm:5.36.1"
+"@strapi/admin@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/admin@npm:5.37.0"
   dependencies:
     "@casl/ability": "npm:6.7.5"
     "@internationalized/date": "npm:3.5.4"
@@ -3729,10 +3585,10 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/permissions": "npm:5.36.1"
-    "@strapi/types": "npm:5.36.1"
-    "@strapi/typescript-utils": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/permissions": "npm:5.37.0"
+    "@strapi/types": "npm:5.37.0"
+    "@strapi/typescript-utils": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.0"
     "@testing-library/user-event": "npm:14.6.1"
@@ -3760,7 +3616,7 @@ __metadata:
     koa-passport: "npm:6.0.0"
     koa-static: "npm:5.0.0"
     koa2-ratelimit: "npm:^1.1.3"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     motion: "npm:12.23.24"
     ora: "npm:5.4.1"
     p-map: "npm:4.0.0"
@@ -3792,15 +3648,15 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/3876ec444835b9a620e418c3e06cbdff746a28cf6d2194d4b7f162640c1f04a7bd905577e33054ef5ba42e3a7541bd786b7e4de8b48642ea3986248b4b72d7e9
+  checksum: 10c0/bfd72ec53cbc16103666e7d6801b559f21c306d21084b130e71e6ea0fb3bd0822697e353221ef8f71539c11f6edcbc56a65f90de2f6bbb79b2e0b02af51dc867
   languageName: node
   linkType: hard
 
-"@strapi/cloud-cli@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/cloud-cli@npm:5.36.1"
+"@strapi/cloud-cli@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/cloud-cli@npm:5.37.0"
   dependencies:
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/utils": "npm:5.37.0"
     axios: "npm:1.13.5"
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
@@ -3813,22 +3669,22 @@ __metadata:
     jsonwebtoken: "npm:9.0.0"
     jwks-rsa: "npm:3.1.0"
     lodash: "npm:4.17.23"
-    minimatch: "npm:9.0.3"
+    minimatch: "npm:10.2.2"
     open: "npm:8.4.0"
     ora: "npm:5.4.1"
     pkg-up: "npm:3.1.0"
-    tar: "npm:7.5.7"
+    tar: "npm:7.5.9"
     xdg-app-paths: "npm:8.3.0"
     yup: "npm:0.32.9"
   bin:
     cloud-cli: bin/index.js
-  checksum: 10c0/4a27a792e53e58abd5b335daa5d627a374820fed8fec15325b65ce9fbf0e9d3e7b0776058711d8d8ceb5f8e026abfe2f5742deb8862dd07192c6931744729a5b
+  checksum: 10c0/e08fb21ef34d7d842d2a851de89f42104fc4fedec561a08b93435ce6abbed36c30214f56ace42364a2b025d6635c00b92878f2388de34b742bcc90e405ef8334
   languageName: node
   linkType: hard
 
-"@strapi/content-manager@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/content-manager@npm:5.36.1"
+"@strapi/content-manager@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/content-manager@npm:5.37.0"
   dependencies:
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/sortable": "npm:10.0.0"
@@ -3838,15 +3694,15 @@ __metadata:
     "@sindresorhus/slugify": "npm:1.1.0"
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/types": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/types": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     codemirror5: "npm:codemirror@^5.65.11"
     date-fns: "npm:2.30.0"
     fractional-indexing: "npm:3.2.0"
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
     koa: "npm:2.16.3"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     markdown-it: "npm:^13.0.2"
     markdown-it-abbr: "npm:^1.0.4"
     markdown-it-container: "npm:^3.0.0"
@@ -3877,24 +3733,24 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/207b6fbf1c32a0728d27736964d9f217dacc5c0b72a9e95620dafff5c18e2c6ba68208cb8605e09c541abc3b07a3f75d77111d192963bcf404495c008cd390d2
+  checksum: 10c0/43dcf2ce1f63f42cebc1813c438e61ca673a01d791ac7e167ae151fc46f403dec86513d699124ad424b7430a932034351e72db67afb5f66c864930fd5c473399
   languageName: node
   linkType: hard
 
-"@strapi/content-releases@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/content-releases@npm:5.36.1"
+"@strapi/content-releases@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/content-releases@npm:5.37.0"
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.7"
-    "@strapi/database": "npm:5.36.1"
+    "@strapi/database": "npm:5.37.0"
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/types": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/types": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:2.0.1"
     formik: "npm:2.4.5"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     qs: "npm:6.14.2"
     react-intl: "npm:6.6.2"
     react-redux: "npm:8.1.3"
@@ -3906,13 +3762,13 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/d922cf215623550576e3107f1b01e92c4fa6a36a262fd4157848665860069080c75d8b9c0e25dd45d46b7b1c63a1a9fb0cccf08af128f728efad58ae2de9e58f
+  checksum: 10c0/1a9e1b8d65acceeebeca2100c5e758530598ab4586a9bfb656dd4474523563516d96f1a8221de0d40829eb8a27670d9c9809881804921bc5ff902e461d2db5e0
   languageName: node
   linkType: hard
 
-"@strapi/content-type-builder@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/content-type-builder@npm:5.36.1"
+"@strapi/content-type-builder@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/content-type-builder@npm:5.37.0"
   dependencies:
     "@ai-sdk/react": "npm:2.0.120"
     "@dnd-kit/core": "npm:6.3.1"
@@ -3922,9 +3778,9 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@sindresorhus/slugify": "npm:1.1.0"
     "@strapi/design-system": "npm:2.1.2"
-    "@strapi/generators": "npm:5.36.1"
+    "@strapi/generators": "npm:5.37.0"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/utils": "npm:5.37.0"
     ai: "npm:5.0.52"
     date-fns: "npm:2.30.0"
     fs-extra: "npm:11.2.0"
@@ -3946,31 +3802,31 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/2d55a4d537846b31aa45899575f8198c4e0e1ada441303c7be77ed56925d83e647eb9106b7ddb85dd459fae55996214ae358102d03856c7d52a9742a980dff82
+  checksum: 10c0/08b15a80f51d9789640f82b523068913878e8b24385e2d8a7b799230622957548175ce101d2482bd9841a5189ba1ec07035cc13c3eb06c2255e4dd0dcf571ae7
   languageName: node
   linkType: hard
 
-"@strapi/core@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/core@npm:5.36.1"
+"@strapi/core@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/core@npm:5.37.0"
   dependencies:
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
     "@paralleldrive/cuid2": "npm:2.2.2"
-    "@strapi/admin": "npm:5.36.1"
-    "@strapi/database": "npm:5.36.1"
-    "@strapi/generators": "npm:5.36.1"
-    "@strapi/logger": "npm:5.36.1"
-    "@strapi/permissions": "npm:5.36.1"
-    "@strapi/types": "npm:5.36.1"
-    "@strapi/typescript-utils": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/admin": "npm:5.37.0"
+    "@strapi/database": "npm:5.37.0"
+    "@strapi/generators": "npm:5.37.0"
+    "@strapi/logger": "npm:5.37.0"
+    "@strapi/permissions": "npm:5.37.0"
+    "@strapi/types": "npm:5.37.0"
+    "@strapi/typescript-utils": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     "@vercel/stega": "npm:0.1.2"
     bcryptjs: "npm:2.4.3"
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
     ci-info: "npm:4.0.0"
-    cli-table3: "npm:0.6.2"
+    cli-table3: "npm:0.6.5"
     commander: "npm:8.3.0"
     configstore: "npm:5.0.1"
     copyfiles: "npm:2.4.1"
@@ -3995,7 +3851,7 @@ __metadata:
     koa-ip: "npm:^2.1.3"
     koa-session: "npm:6.4.0"
     koa-static: "npm:5.0.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     mime-types: "npm:2.1.35"
     node-schedule: "npm:2.1.1"
     open: "npm:8.4.0"
@@ -4010,50 +3866,50 @@ __metadata:
     undici: "npm:6.23.0"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
-  checksum: 10c0/037988a046bbdf112a6f0385db23f9bad30d89f8887ed83d72021361125877a96f6d83730beb343fd3cc7349b3a163be3a0ac8d7e21f61a379f4b53df8c7bd15
+  checksum: 10c0/6edda90aec556202508470209a5a37d63dd3af89b43593a4c53edfb5cac7b89afb78edfb832d726228a7f20b2f4b33f33145b85708704f0b71bc8ba923262bd4
   languageName: node
   linkType: hard
 
-"@strapi/data-transfer@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/data-transfer@npm:5.36.1"
+"@strapi/data-transfer@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/data-transfer@npm:5.37.0"
   dependencies:
-    "@strapi/logger": "npm:5.36.1"
-    "@strapi/types": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/logger": "npm:5.37.0"
+    "@strapi/types": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
     commander: "npm:8.3.0"
     fs-extra: "npm:11.2.0"
     inquirer: "npm:8.2.5"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     ora: "npm:5.4.1"
     resolve-cwd: "npm:3.0.0"
     semver: "npm:7.5.4"
     stream-chain: "npm:2.2.5"
     stream-json: "npm:1.8.0"
-    tar: "npm:7.5.7"
+    tar: "npm:7.5.9"
     tar-stream: "npm:2.2.0"
     ws: "npm:8.17.1"
-  checksum: 10c0/c13bafabbd2f8017e42966ffb5dfdb48fb40794f85d7b169ac5644973b3827f315c638ed67dfd995597267ac85c2343e22aac72b07834a2523b2aa40c47fdc73
+  checksum: 10c0/04447df1fe4b7263e280a40b238c10f73f3e941667f5878cf7a075ba87f059af41aa0880b05f5d2a711ab64dd52f51fd3e0c704e140332e0ac33f18eaf4f1d31
   languageName: node
   linkType: hard
 
-"@strapi/database@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/database@npm:5.36.1"
+"@strapi/database@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/database@npm:5.37.0"
   dependencies:
     "@paralleldrive/cuid2": "npm:2.2.2"
-    "@strapi/utils": "npm:5.36.1"
-    ajv: "npm:8.16.0"
+    "@strapi/utils": "npm:5.37.0"
+    ajv: "npm:8.18.0"
     date-fns: "npm:2.30.0"
     debug: "npm:4.3.4"
     fs-extra: "npm:11.2.0"
     knex: "npm:3.0.1"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     semver: "npm:7.5.4"
     umzug: "npm:3.8.1"
-  checksum: 10c0/da7ce0203b06dc6b588861bbef7a61a32c0592250a63e3fb2e9dc2ba18ed8478867f1813b8f7b1dd2ae10e6d73ec89de95a8d517b2c6fea4a0f4b1119ac188b5
+  checksum: 10c0/bd07a1ece6f092f4e0f081546c95fc3026d35e6a13a1badd2e57811a54098aaed8b06f766be2b21c184aea85364cfdffab28ad052e2c1eb46821608018c8e2a4
   languageName: node
   linkType: hard
 
@@ -4133,16 +3989,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/email@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/email@npm:5.36.1"
+"@strapi/email@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/email@npm:5.37.0"
   dependencies:
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/provider-email-sendmail": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/provider-email-sendmail": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     koa2-ratelimit: "npm:^1.1.3"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     react-intl: "npm:6.6.2"
     react-query: "npm:3.39.3"
     yup: "npm:0.32.9"
@@ -4154,17 +4010,17 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/42a3ef7b4e46849f8773866fbd78f2d0912ea669e73b851c089180ffd3376282578a2e56f8843468b34adb5384833a51430fcaa2e78ec29aa767b8b4b6bad2d4
+  checksum: 10c0/5a406541acd700733f024515ce9ddc57adc175e58d48b11a5e5e7a94306623e4cb9eca5441e3867e5a33248f8786183be525d42341df4549db70802f6a0b99d0
   languageName: node
   linkType: hard
 
-"@strapi/generators@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/generators@npm:5.36.1"
+"@strapi/generators@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/generators@npm:5.37.0"
   dependencies:
     "@sindresorhus/slugify": "npm:1.1.0"
-    "@strapi/typescript-utils": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/typescript-utils": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     chalk: "npm:4.1.2"
     copyfiles: "npm:2.4.1"
     fs-extra: "npm:11.2.0"
@@ -4173,18 +4029,18 @@ __metadata:
     lodash: "npm:4.17.23"
     plop: "npm:4.0.1"
     pluralize: "npm:8.0.0"
-  checksum: 10c0/4874c1d7c2fdb460de1bdf21a231fd7cad76ac2a8ea83a00188f4088fc53994961ca240e8cbcfa12d61740124b4debe2ef53e42a1592babae7c21f028b02dff2
+  checksum: 10c0/16cc456d43621455974de8cba16033543b5ce1f4e519c242718aa113aa0db82799231ee440b901c8ce0f6b294d1249286771e972a44d5fc381fc145b2154e27e
   languageName: node
   linkType: hard
 
-"@strapi/i18n@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/i18n@npm:5.36.1"
+"@strapi/i18n@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/i18n@npm:5.37.0"
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/utils": "npm:5.37.0"
     lodash: "npm:4.17.23"
     qs: "npm:6.14.2"
     react-intl: "npm:6.6.2"
@@ -4198,7 +4054,7 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/9163fd8bfcf572d39aa67dcaa4f9ada776fef384adb8fb3c088dc2f623779f224d6b38e5e3e0f6799b6c635f8f320b21c91b78197d1bbac8f5fecf906d899433
+  checksum: 10c0/27cee5aa158f21be8423f59aa93d8104285989db3f42e5dec838f907fa6b53894cde69b550098e80f374d549c15f8ce72565cf2291e537ecc72d88c40860660e
   languageName: node
   linkType: hard
 
@@ -4224,43 +4080,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/logger@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/logger@npm:5.36.1"
+"@strapi/logger@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/logger@npm:5.37.0"
   dependencies:
     lodash: "npm:4.17.23"
     winston: "npm:3.10.0"
-  checksum: 10c0/13603c6aa4697f4a7c02748c81bf9d5a26a37620841863829a8b36901ea008a4300bea55f3d6551aed9177db7808405808b7b0d24fcb13a1c2a4cf2c27c9350a
+  checksum: 10c0/6cab8933b92e66bb018bef63ad56b55ff7744c0edbf8d579315c53b61f2f464fe7d9dd7f60f198bb88bff6b224cc1c72fa3198993762c1771031966b5a5a8967
   languageName: node
   linkType: hard
 
-"@strapi/openapi@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/openapi@npm:5.36.1"
+"@strapi/openapi@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/openapi@npm:5.37.0"
   dependencies:
     debug: "npm:4.3.4"
     openapi-types: "npm:12.1.3"
     zod: "npm:3.25.67"
-  checksum: 10c0/601c22c4b3f0fbd8bddc5f366179df03fc116ba52da5d99191107ffec103973bd2164573b65552f73767c162fedcc16db3d0caf245050450d12883761c397b60
+  checksum: 10c0/83bf8c52966e25d3e3260e458f77f7fd4f32cbf60a6cf33536acf91b65c061de42deee116388ce54a96af198568edb2d266c48f82989c3b8e95154ff1a0979a7
   languageName: node
   linkType: hard
 
-"@strapi/permissions@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/permissions@npm:5.36.1"
+"@strapi/permissions@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/permissions@npm:5.37.0"
   dependencies:
     "@casl/ability": "npm:6.7.5"
-    "@strapi/utils": "npm:5.36.1"
-    lodash: "npm:4.17.21"
+    "@strapi/utils": "npm:5.37.0"
+    lodash: "npm:4.17.23"
     qs: "npm:6.14.2"
     sift: "npm:16.0.1"
-  checksum: 10c0/95541518813815ca3f7c47b5d51f37969c8bf85bdda5111eb9b9b1a0f3fa38dd8e399509b88686496bf6b9e11188e6fbcf781f277d2098cf01be3ef97d261d48
+  checksum: 10c0/fba895a87a26a50bfd5698505c1ca92a1914366f1f70e50c00e9070697003773931ba57a501811f081a991730345b47c0ce3518619316fd828c7e10693e78005
   languageName: node
   linkType: hard
 
-"@strapi/plugin-cloud@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/plugin-cloud@npm:5.36.1"
+"@strapi/plugin-cloud@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/plugin-cloud@npm:5.37.0"
   dependencies:
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
@@ -4272,7 +4128,7 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/30654a3a05ffe502b60c93ad0f61f5b9b04197510a460d692bc6048ddee721b23b90231ae1cd265d891275b98bc73c2ce4fb73c4aa9dc480ae93f94d9d89ae4a
+  checksum: 10c0/547e3c6ab915d58ddc81d73f0a2d65badee375b5e5cc97b2af38f95da3207513eca44df4a7fae49d8aa103259714269748158972cf3bec3c44525a4686cbeba2
   languageName: node
   linkType: hard
 
@@ -4297,13 +4153,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/plugin-users-permissions@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/plugin-users-permissions@npm:5.36.1"
+"@strapi/plugin-users-permissions@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/plugin-users-permissions@npm:5.37.0"
   dependencies:
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/utils": "npm:5.37.0"
     bcryptjs: "npm:2.4.3"
     formik: "npm:2.4.5"
     grant: "npm:^5.4.8"
@@ -4327,38 +4183,38 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/4f24a4cfa86e0887a49f905f12933011fe4cc092882c0a10b8c586da32723cdf8e49970f6004872e6eb521154f634bbc76d9c81fec5bd30d2256bda649c0d941
+  checksum: 10c0/b5ddff04d1a319b9333975c4ffefedc99625d9fc92ecc9ab2f311a0149e8039f141ad889cf0a42a2208543da87b72040375fd88e0db13c3c3883b62ad683458b
   languageName: node
   linkType: hard
 
-"@strapi/provider-email-sendmail@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/provider-email-sendmail@npm:5.36.1"
+"@strapi/provider-email-sendmail@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/provider-email-sendmail@npm:5.37.0"
   dependencies:
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/utils": "npm:5.37.0"
     sendmail: "npm:^1.6.1"
-  checksum: 10c0/c5bee5ab75a0725b72893f0ba6e17d2c970b95e1d1c74b73fadcbb62ff0009161e113f11621fbee07eb95f4b3f4eb9ca8df1c0149aed61769f5d8fbf7b567199
+  checksum: 10c0/ca7a7668a5edd64d1e95dbcb4f3a542ae7e80f52734a75685924f2bbd90379ecf4dee9eb224ff5888eb7cff8630da591b4ae3f5e5b2fcaacaccc789d16c42fa1
   languageName: node
   linkType: hard
 
-"@strapi/provider-upload-local@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/provider-upload-local@npm:5.36.1"
+"@strapi/provider-upload-local@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/provider-upload-local@npm:5.37.0"
   dependencies:
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/utils": "npm:5.37.0"
     fs-extra: "npm:11.2.0"
-  checksum: 10c0/48cf77f5b48b64103d4e55df57f677509dd3ff3b0a92a3c9d21614b6ee3b922dd5540ace4accac34dedcf1aa3931310119e18350b76ece03e27204b27e4055ad
+  checksum: 10c0/f43a011c40c3e4124acf467ec449636bed95de695073c90fb8e820e6bf92febd08e554b8905e1c563e246026a3c059de288047f139231fe2510c0f32c1d8a08e
   languageName: node
   linkType: hard
 
-"@strapi/review-workflows@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/review-workflows@npm:5.36.1"
+"@strapi/review-workflows@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/review-workflows@npm:5.37.0"
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/utils": "npm:5.37.0"
     fractional-indexing: "npm:3.2.0"
     react-dnd: "npm:16.0.1"
     react-dnd-html5-backend: "npm:16.0.1"
@@ -4373,34 +4229,34 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/8aa93ca7944b7b7f30d6b074e8c953a4b7c227cf3533ff76895f73cca5330ab85ad83d1738b1122db05204138ddc8f59c563105361d0b409ea35fd0738ab0dc5
+  checksum: 10c0/604445c23b48bcc89b19c8ad4a875acdc6290a39ff81367772b2d1257175a738cc4f487c5fa9187a65b849bc5f2e852decbfc99a0835009d0417ae22d26bf49a
   languageName: node
   linkType: hard
 
-"@strapi/strapi@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/strapi@npm:5.36.1"
+"@strapi/strapi@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/strapi@npm:5.37.0"
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin": "npm:0.5.15"
-    "@strapi/admin": "npm:5.36.1"
-    "@strapi/cloud-cli": "npm:5.36.1"
-    "@strapi/content-manager": "npm:5.36.1"
-    "@strapi/content-releases": "npm:5.36.1"
-    "@strapi/content-type-builder": "npm:5.36.1"
-    "@strapi/core": "npm:5.36.1"
-    "@strapi/data-transfer": "npm:5.36.1"
-    "@strapi/database": "npm:5.36.1"
-    "@strapi/email": "npm:5.36.1"
-    "@strapi/generators": "npm:5.36.1"
-    "@strapi/i18n": "npm:5.36.1"
-    "@strapi/logger": "npm:5.36.1"
-    "@strapi/openapi": "npm:5.36.1"
-    "@strapi/permissions": "npm:5.36.1"
-    "@strapi/review-workflows": "npm:5.36.1"
-    "@strapi/types": "npm:5.36.1"
-    "@strapi/typescript-utils": "npm:5.36.1"
-    "@strapi/upload": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/admin": "npm:5.37.0"
+    "@strapi/cloud-cli": "npm:5.37.0"
+    "@strapi/content-manager": "npm:5.37.0"
+    "@strapi/content-releases": "npm:5.37.0"
+    "@strapi/content-type-builder": "npm:5.37.0"
+    "@strapi/core": "npm:5.37.0"
+    "@strapi/data-transfer": "npm:5.37.0"
+    "@strapi/database": "npm:5.37.0"
+    "@strapi/email": "npm:5.37.0"
+    "@strapi/generators": "npm:5.37.0"
+    "@strapi/i18n": "npm:5.37.0"
+    "@strapi/logger": "npm:5.37.0"
+    "@strapi/openapi": "npm:5.37.0"
+    "@strapi/permissions": "npm:5.37.0"
+    "@strapi/review-workflows": "npm:5.37.0"
+    "@strapi/types": "npm:5.37.0"
+    "@strapi/typescript-utils": "npm:5.37.0"
+    "@strapi/upload": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     "@types/nodemon": "npm:1.19.6"
     "@vitejs/plugin-react-swc": "npm:3.6.0"
     boxen: "npm:5.1.2"
@@ -4408,7 +4264,7 @@ __metadata:
     browserslist-to-esbuild: "npm:1.2.0"
     chalk: "npm:4.1.2"
     chokidar: "npm:3.6.0"
-    ci-info: "npm:3.8.0"
+    ci-info: "npm:4.0.0"
     cli-progress: "npm:3.12.0"
     cli-table3: "npm:0.6.5"
     commander: "npm:8.3.0"
@@ -4425,7 +4281,7 @@ __metadata:
     git-url-parse: "npm:14.0.0"
     html-webpack-plugin: "npm:5.6.0"
     inquirer: "npm:8.2.5"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     mini-css-extract-plugin: "npm:2.7.7"
     nodemon: "npm:3.0.2"
     ora: "npm:5.4.1"
@@ -4452,21 +4308,21 @@ __metadata:
     styled-components: ^6.0.0
   bin:
     strapi: bin/strapi.js
-  checksum: 10c0/7c60f49819970a5968f50fbb9fd4461bfe4eb559ea7ed5bce84a098828d649dc6f7fc599d4700c2b8f0d3f6baaf38b38c48a89eb6eb8a684f9dcf492ccbe0539
+  checksum: 10c0/626863baacbefbc01b89a7502a80c585be8b5e4f9861f7847ab256bd0e3bb405049801d67df243127435e0080ad78df146229e3b9bec86f05b1b0a20b793d1a2
   languageName: node
   linkType: hard
 
-"@strapi/types@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/types@npm:5.36.1"
+"@strapi/types@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/types@npm:5.37.0"
   dependencies:
     "@casl/ability": "npm:6.7.5"
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
-    "@strapi/database": "npm:5.36.1"
-    "@strapi/logger": "npm:5.36.1"
-    "@strapi/permissions": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/database": "npm:5.37.0"
+    "@strapi/logger": "npm:5.37.0"
+    "@strapi/permissions": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     commander: "npm:8.3.0"
     json-logic-js: "npm:2.0.5"
     koa: "npm:2.16.3"
@@ -4476,13 +4332,13 @@ __metadata:
     typedoc-github-wiki-theme: "npm:1.1.0"
     typedoc-plugin-markdown: "npm:3.17.1"
     zod: "npm:3.25.67"
-  checksum: 10c0/434ece982d084537e7a4c8535d584069054809e0dd3b1f15dd1c14b4401b0c715bf1bdbc508d34e7136d7ce3ba10b32a7c47d05353a12f68bb068b41b3ab467d
+  checksum: 10c0/8dbb99ad08813d34056c32fb1ab1d1ce4865210125f92b2ebdd2fa6f5c0aaeadea2b19fade78ca8705279c3b4f28801033ece405df4e73e3b69f0ca97ea2a5d5
   languageName: node
   linkType: hard
 
-"@strapi/typescript-utils@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/typescript-utils@npm:5.36.1"
+"@strapi/typescript-utils@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/typescript-utils@npm:5.37.0"
   dependencies:
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
@@ -4490,7 +4346,7 @@ __metadata:
     lodash: "npm:4.17.23"
     prettier: "npm:3.3.3"
     typescript: "npm:5.4.4"
-  checksum: 10c0/9babb93a7bc027fd8e352389b66829866eff53f2f112ab06117329b011a4498c6df46340b895c31ddfb4b1ccfa7d311bc6c3b7ce09b988b0dbd8b865c61acc49
+  checksum: 10c0/4d7192b578d5f69f8bf9f2ea3301c2eff93b4c3f4822bc86d1b545b93598f3025adbc637f61f36057a3b2336b865650fa7c8d8537ee4e071cb3bc0618ad6bde6
   languageName: node
   linkType: hard
 
@@ -4557,19 +4413,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/upload@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/upload@npm:5.36.1"
+"@strapi/upload@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/upload@npm:5.37.0"
   dependencies:
     "@mux/mux-player-react": "npm:3.1.0"
-    "@radix-ui/react-dialog": "npm:1.1.15"
+    "@radix-ui/react-dialog": "npm:1.0.5"
     "@radix-ui/react-toggle-group": "npm:1.1.11"
     "@reduxjs/toolkit": "npm:1.9.7"
-    "@strapi/database": "npm:5.36.1"
+    "@strapi/database": "npm:5.37.0"
     "@strapi/design-system": "npm:2.1.2"
     "@strapi/icons": "npm:2.1.2"
-    "@strapi/provider-upload-local": "npm:5.36.1"
-    "@strapi/utils": "npm:5.36.1"
+    "@strapi/provider-upload-local": "npm:5.37.0"
+    "@strapi/utils": "npm:5.37.0"
     byte-size: "npm:8.1.1"
     cropperjs: "npm:1.6.1"
     date-fns: "npm:2.30.0"
@@ -4579,7 +4435,7 @@ __metadata:
     immer: "npm:9.0.21"
     koa-range: "npm:0.3.0"
     koa-static: "npm:5.0.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     mime-types: "npm:2.1.35"
     prop-types: "npm:^15.8.1"
     qs: "npm:6.14.2"
@@ -4597,25 +4453,25 @@ __metadata:
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
-  checksum: 10c0/2c0e468942255f1db7d365b00f63fcd133d7fb9b9d8e8c4985253fdec31fd31e20dd5dcee437f75f720b6d8efeec06bcf646d6cf9f8ecb84e53c04aafda3ec8b
+  checksum: 10c0/e3635c59dcaca2408d7fda21622e87dd62fd54f8291bc8ea75a20c5bdca2807e1a480e424a6f52b6300e56e1644d6b588d2894764359ce8bbf2435d68abc2bd0
   languageName: node
   linkType: hard
 
-"@strapi/utils@npm:5.36.1":
-  version: 5.36.1
-  resolution: "@strapi/utils@npm:5.36.1"
+"@strapi/utils@npm:5.37.0":
+  version: 5.37.0
+  resolution: "@strapi/utils@npm:5.37.0"
   dependencies:
     "@sindresorhus/slugify": "npm:1.1.0"
     date-fns: "npm:2.30.0"
     execa: "npm:5.1.1"
     http-errors: "npm:2.0.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     node-machine-id: "npm:1.1.12"
     p-map: "npm:4.0.0"
     preferred-pm: "npm:3.1.3"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
-  checksum: 10c0/987e2063652ac51ecaff4e2f850c0a2ffcca79b6e15428db68acfcc5ea56131c3ebb8ddf5d70056df4bf454d43e02c58b17ba6da3933af9ec48fceb5b664c872
+  checksum: 10c0/881bd78790bae1d5689dcb76054d31a59fc086d52508e48cd2ece2d8f100d5b23282fd1aa98c008e4f31bfd3fb37c4abafc696ddb830cc051073a0f6ec7948a8
   languageName: node
   linkType: hard
 
@@ -5828,15 +5684,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.16.0":
-  version: 8.16.0
-  resolution: "ajv@npm:8.16.0"
+"ajv@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ajv@npm:8.18.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-    uri-js: "npm:^4.4.1"
-  checksum: 10c0/6fc38aa8fd4fbfaa7096ac049e48c0cb440db36b76fef2d7d5b7d92b102735670d055d412d19176c08c9d48eaa9d06661b67e59f04943dc71ab1551e0484f88c
+  checksum: 10c0/e7517c426173513a07391be951879932bdf3348feaebd2199f5b901c20f99d60db8cd1591502d4d551dc82f594e82a05c4fe1c70139b15b8937f7afeaed9532f
   languageName: node
   linkType: hard
 
@@ -5998,7 +5854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-hidden@npm:^1.1.1, aria-hidden@npm:^1.2.4":
+"aria-hidden@npm:^1.1.1":
   version: 1.2.6
   resolution: "aria-hidden@npm:1.2.6"
   dependencies:
@@ -6112,6 +5968,13 @@ __metadata:
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
+  languageName: node
+  linkType: hard
+
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
   languageName: node
   linkType: hard
 
@@ -6234,6 +6097,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.2":
+  version: 5.0.3
+  resolution: "brace-expansion@npm:5.0.3"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/e474d300e581ec56851b3863ff1cf18573170c6d06deb199ccbd03b2119c36975f6ce2abc7b770f5bebddc1ab022661a9fea9b4d56f33315d7bef54d8793869e
   languageName: node
   linkType: hard
 
@@ -6578,13 +6450,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:3.8.0":
-  version: 3.8.0
-  resolution: "ci-info@npm:3.8.0"
-  checksum: 10c0/0d3052193b58356372b34ab40d2668c3e62f1006d5ca33726d1d3c423853b19a85508eadde7f5908496fb41448f465263bf61c1ee58b7832cb6a924537e3863a
-  languageName: node
-  linkType: hard
-
 "ci-info@npm:4.0.0":
   version: 4.0.0
   resolution: "ci-info@npm:4.0.0"
@@ -6646,19 +6511,6 @@ __metadata:
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
-  languageName: node
-  linkType: hard
-
-"cli-table3@npm:0.6.2":
-  version: 0.6.2
-  resolution: "cli-table3@npm:0.6.2"
-  dependencies:
-    "@colors/colors": "npm:1.5.0"
-    string-width: "npm:^4.2.0"
-  dependenciesMeta:
-    "@colors/colors":
-      optional: true
-  checksum: 10c0/aaa87929d86ba36e651e0280ab34cc28660e13da9dd2b6f8aa36e800c40e331c32bff53597cb9126e8a2e88e7a9025aff9c240350fe69876207d51ba452ef5e0
   languageName: node
   linkType: hard
 
@@ -11674,12 +11526,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:9.0.3":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
+"minimatch@npm:10.2.2":
+  version: 10.2.2
+  resolution: "minimatch@npm:10.2.2"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/85f407dcd38ac3e180f425e86553911d101455ca3ad5544d6a7cec16286657e4f8a9aa6695803025c55e31e35a91a2252b5dc8e7d527211278b8b65b4dbd5eac
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10c0/098831f2f542cb802e1f249c809008a016e1fef6b3a9eda9cf9ecb2b3d7979083951bd47c0c82fcf34330bd3b36638a493d4fa8e24cce58caf5b481de0f4e238
   languageName: node
   linkType: hard
 
@@ -13409,7 +13261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-remove-scroll-bar@npm:^2.3.3, react-remove-scroll-bar@npm:^2.3.6, react-remove-scroll-bar@npm:^2.3.7":
+"react-remove-scroll-bar@npm:^2.3.3, react-remove-scroll-bar@npm:^2.3.6":
   version: 2.3.8
   resolution: "react-remove-scroll-bar@npm:2.3.8"
   dependencies:
@@ -13460,25 +13312,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/4952657e6a7b9d661d4ad4dfcef81b9c7fa493e35164abff99c35c0b27b3d172ef7ad70c09416dc44dd14ff2e6b38a5ec7da27e27e90a15cbad36b8fd2fd8054
-  languageName: node
-  linkType: hard
-
-"react-remove-scroll@npm:^2.6.3":
-  version: 2.7.2
-  resolution: "react-remove-scroll@npm:2.7.2"
-  dependencies:
-    react-remove-scroll-bar: "npm:^2.3.7"
-    react-style-singleton: "npm:^2.2.3"
-    tslib: "npm:^2.1.0"
-    use-callback-ref: "npm:^1.3.3"
-    use-sidecar: "npm:^1.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/b5f3315bead75e72853f492c0b51ba8fb4fa09a4534d7fc42d6fcd59ca3e047cf213279ffc1e35b337e314ef5a04cb2b12544c85e0078802271731c27c09e5aa
   languageName: node
   linkType: hard
 
@@ -13535,7 +13368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-style-singleton@npm:^2.2.1, react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
+"react-style-singleton@npm:^2.2.1, react-style-singleton@npm:^2.2.2":
   version: 2.2.3
   resolution: "react-style-singleton@npm:2.2.3"
   dependencies:
@@ -14809,10 +14642,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "strapi@workspace:."
   dependencies:
-    "@strapi/plugin-cloud": "npm:5.36.1"
+    "@strapi/plugin-cloud": "npm:5.37.0"
     "@strapi/plugin-seo": "npm:^2.0.4"
-    "@strapi/plugin-users-permissions": "npm:5.36.1"
-    "@strapi/strapi": "npm:5.36.1"
+    "@strapi/plugin-users-permissions": "npm:5.37.0"
+    "@strapi/strapi": "npm:5.37.0"
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
@@ -15119,16 +14952,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.7":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+"tar@npm:7.5.9":
+  version: 7.5.9
+  resolution: "tar@npm:7.5.9"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  checksum: 10c0/e870beb1b2477135ca2abe86b2d18f7b35d0a4e3a37bbc523d3b8f7adca268dfab543f26528a431d569897f8c53a7cac745cdfbc4411c2f89aeeacc652b81b0a
   languageName: node
   linkType: hard
 
@@ -15792,7 +15625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-callback-ref@npm:^1.3.0, use-callback-ref@npm:^1.3.3":
+"use-callback-ref@npm:^1.3.0":
   version: 1.3.3
   resolution: "use-callback-ref@npm:1.3.3"
   dependencies:
@@ -15836,7 +15669,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sidecar@npm:^1.1.2, use-sidecar@npm:^1.1.3":
+"use-sidecar@npm:^1.1.2":
   version: 1.1.3
   resolution: "use-sidecar@npm:1.1.3"
   dependencies:


### PR DESCRIPTION
### What does it do?

Added some hydration submission messages so we don't get the next issue in live preview running in dev mode. 
Upgraded Strapi to latest version. Adjusted the draft mode banner so it does not show in live preview. 

### Why is it needed?

Reports of some minor issues on the demo and syncing Strapi to latest version for responsive admin dashboard. 

### How to test it?

Simply make sure the whole Strapi application doesn't crash and the connected Next.js application is fully working.

Some additional things to check:

- [x] Strapi project uuid is "LAUNCHPAD". `strapi/packages.json`.
- [x] Strapi version is the latest possible.
- [x] If the Strapi version has been changed, make sure that the `strapi/scripts/prefillLoginFields.js` works.
- [x] If you updated content, make sure to create a new export in the `strapi/data` folder and update the `strapi/packages.json` seed command if necessary.

### Related issue(s)/PR(s)

#115 