### PR TITLE
fix: remove undeclared glob dependency from prefillLoginFields.js

### DIFF
--- a/strapi/scripts/prefillLoginFields.js
+++ b/strapi/scripts/prefillLoginFields.js
@@ -1,11 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
 
-// Base directory and target file patterns
+// Base directory and target files
 const directoryPath =
   './node_modules/@strapi/admin/dist/admin/admin/src/pages/Auth/components';
-const targetFiles = ['Login.js', 'Login.mjs']; // You can add more file patterns here
+const targetFiles = ['Login.js', 'Login.mjs']; // You can add more files here
 
 // Content to replace
 const originalContent = `initialValues: {
@@ -20,50 +19,31 @@ const newContent = `initialValues: {
                                 rememberMe: false
                             },`;
 
-// Function to update a given file
-const updateFile = (filePath) => {
-  fs.readFile(filePath, 'utf8', (err, data) => {
-    if (err) {
-      console.error(`❌ Error reading file ${filePath}:`, err);
-      return;
-    }
+let found = 0;
 
-    if (data.includes(newContent)) {
-      console.log(
-        `✅ File already modified with demo credentials: ${filePath}`
-      );
-      return;
-    }
+targetFiles.forEach((file) => {
+  const filePath = path.join(directoryPath, file);
 
-    if (data.includes(originalContent)) {
-      const updatedData = data.replace(originalContent, newContent);
+  if (!fs.existsSync(filePath)) {
+    console.log(`⚠️ No matching file found for: ${file}`);
+    return;
+  }
 
-      fs.writeFile(filePath, updatedData, 'utf8', (err) => {
-        if (err) {
-          console.error(`❌ Error writing to file ${filePath}:`, err);
-          return;
-        }
-        console.log(`✅ Successfully updated: ${filePath}`);
-      });
-    } else {
-      console.log(`⚠️ Original content not found in: ${filePath}`);
-    }
-  });
-};
+  found++;
+  const data = fs.readFileSync(filePath, 'utf8');
 
-// Iterate over each file pattern
-targetFiles.forEach((pattern) => {
-  glob(path.join(directoryPath, pattern), (err, files) => {
-    if (err) {
-      console.error('❌ Error finding files:', err);
-      return;
-    }
-
-    if (files.length > 0) {
-      files.forEach(updateFile);
-    } else {
-      console.log(`⚠️ No matching files found for: ${pattern}`);
-      process.exit(1);
-    }
-  });
+  if (data.includes(newContent)) {
+    console.log(`✅ File already modified with demo credentials: ${filePath}`);
+  } else if (data.includes(originalContent)) {
+    fs.writeFileSync(filePath, data.replace(originalContent, newContent), 'utf8');
+    console.log(`✅ Successfully updated: ${filePath}`);
+  } else {
+    console.log(`⚠️ Original content not found in: ${filePath}`);
+    process.exit(1);
+  }
 });
+
+if (found === 0) {
+  console.error('❌ No Login.js / Login.mjs found — admin dist layout may have changed.');
+  process.exit(1);
+}


### PR DESCRIPTION
### What does it do?

Rewrites `strapi/scripts/prefillLoginFields.js` to use plain synchronous `fs` instead of the `glob` package:

- Removes `require('glob')` and the callback-style `glob()` call. The script only targets two literal filenames (`Login.js`, `Login.mjs`) in one fixed directory — no wildcards — so glob was never needed.
- Switches from async `fs.readFile`/`fs.writeFile` callbacks to `fs.existsSync`/`fs.readFileSync`/`fs.writeFileSync`.
- Tightens exit-code behavior: the previous async version swallowed write errors and content mismatches, so a build could silently ship a demo without prefilled credentials. The script now exits 1 if no target file exists at all, or if a file matches neither the original nor the patched content.
- `directoryPath`, `targetFiles`, `originalContent`, `newContent` and the console messages are unchanged.

### Why is it needed?

**The demo deploy pipeline is fully blocked.** The demo-operator GitLab pipeline (kaniko) clones this repo fresh on every build and bakes the Strapi demo image. In the image's final stage, the prefill script is the **first command** in the build `RUN` chain:

```
RUN node scripts/prefillLoginFields.js && \
    /opt/extend-strapi-restart-timeout && \
    yarn build && \
    yarn seed --force && \
    yarn strapi admin:create -e admin@strapidemo.com -p ...
```

Since #129 it crashes immediately, so the admin build, demo seeding, and admin-user creation never run, no image is produced, and the deploy job fails:

```
/app/scripts/prefillLoginFields.js:56
  glob(path.join(directoryPath, pattern), (err, files) => {
  ^
TypeError: glob is not a function
    at /app/scripts/prefillLoginFields.js:56:3
Node.js v22.22.3
error building image: error building stage: failed to execute command: exit status 1
ERROR: Job failed: exit code 1
```

Root cause:

- The script called `glob` with the **callback API**, which only exists in glob ≤ v8. In v9+, `require('glob')` returns an object (`{ glob, globSync, ... }`), not a function.
- `glob` was **never declared** in `strapi/package.json` — it only resolved through `node_modules` hoisting (`nodeLinker: node-modules`).
- #129 bumped `@strapi/strapi` to 5.47.1, which depends on `glob@13.0.6`. v13 now wins hoisting to `node_modules/glob`, so the old callback call crashes.

Because the Dockerfile clones the default branch unpinned, every demo build picks this up — and it stays broken until this fix lands on `main`.

Removing the undeclared transitive dependency fixes it for good — pinning glob@^8 or migrating to the new glob API would still leave an undeclared dependency that breaks again on a future Strapi bump.

### How to test it?

In `strapi/`:

1. `yarn install`
2. `node scripts/prefillLoginFields.js` → exits 0, prints ✅ for both `Login.js` and `Login.mjs`
3. Run it again → prints "already modified" and exits 0 (idempotent — also covers kaniko layer retries)
4. `yarn build` and log in to the admin → email/password come prefilled with the demo credentials

Verified locally against 5.47.1: the `initialValues` block in the admin dist still matches `originalContent` exactly (no string drift), and `grep -rn "require('glob')" scripts/` returns nothing.

### Related issue(s)/PR(s)

Broke after #129 (Strapi 5.42.1 → 5.47.1). Blocks the demo deploy pipeline — cc @alex-strapi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)