### PR TITLE
fix: block-editor images break outside the authoring environment

### DIFF
--- a/next/app/[locale]/(marketing)/blog/[slug]/page.tsx
+++ b/next/app/[locale]/(marketing)/blog/[slug]/page.tsx
@@ -1,7 +1,5 @@
-import { BlocksRenderer } from '@strapi/blocks-react-renderer';
-import React from 'react';
-
 import ClientSlugHandler from '../../ClientSlugHandler';
+import { ArticleContent } from '@/components/article-content';
 import { BlogLayout } from '@/components/blog-layout';
 import { fetchCollectionType } from '@/lib/strapi';
 import type { Article, LocaleSlugParamsProps } from '@/types/types';
@@ -34,7 +32,7 @@ export default async function SingleArticlePage({
   return (
     <BlogLayout article={article} locale={locale}>
       <ClientSlugHandler localizedSlugs={localizedSlugs} />
-      <BlocksRenderer content={article.content} />
+      <ArticleContent content={article.content} />
     </BlogLayout>
   );
 }

--- a/next/components/article-content.tsx
+++ b/next/components/article-content.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import {
+  BlocksRenderer,
+  type BlocksContent,
+} from '@strapi/blocks-react-renderer';
+import type { ComponentProps } from 'react';
+
+import { BlurImage } from './blur-image';
+import { normalizeStrapiMediaUrl, stripStegaMarkers } from '@/lib/utils';
+
+type BlockComponents = NonNullable<
+  ComponentProps<typeof BlocksRenderer>['blocks']
+>;
+
+const ImageBlock: BlockComponents['image'] = ({ image }) => (
+  <BlurImage
+    src={normalizeStrapiMediaUrl(image.url)}
+    alt={stripStegaMarkers(image.alternativeText || image.name)}
+    width={image.width}
+    height={image.height}
+    className="rounded-lg"
+  />
+);
+
+export const ArticleContent = ({ content }: { content: BlocksContent }) => {
+  return <BlocksRenderer content={content} blocks={{ image: ImageBlock }} />;
+};

--- a/next/components/ui/strapi-media.tsx
+++ b/next/components/ui/strapi-media.tsx
@@ -1,4 +1,4 @@
-import { API_URL } from '@/lib/utils';
+import { API_URL, stripStegaMarkers } from '@/lib/utils';
 import { unstable_noStore as noStore } from 'next/cache';
 import Image from 'next/image';
 import {
@@ -18,10 +18,11 @@ interface StrapiMediaProps
 
 export function getStrapiMedia(url: string | null) {
   if (url == null) return null;
-  if (url.startsWith('data:')) return url;
-  if (url.startsWith('http') || url.startsWith('//')) return url;
+  const cleanUrl = stripStegaMarkers(url);
+  if (cleanUrl.startsWith('data:')) return cleanUrl;
+  if (cleanUrl.startsWith('http') || cleanUrl.startsWith('//')) return cleanUrl;
 
-  return API_URL + url;
+  return API_URL + cleanUrl;
 }
 
 /**

--- a/next/lib/strapi/strapiImage.ts
+++ b/next/lib/strapi/strapiImage.ts
@@ -1,12 +1,14 @@
 import { unstable_noStore as noStore } from 'next/cache';
-import { API_URL } from '../utils';
+import { API_URL, stripStegaMarkers } from '../utils';
 
 export function strapiImage(url: string): string {
   noStore();
 
-  if (url.startsWith('/')) {
-    return API_URL + url;
+  const cleanUrl = stripStegaMarkers(url);
+
+  if (cleanUrl.startsWith('/')) {
+    return API_URL + cleanUrl;
   }
 
-  return url;
+  return cleanUrl;
 }

--- a/next/lib/utils.ts
+++ b/next/lib/utils.ts
@@ -23,3 +23,26 @@ export const formatNumber = (
 
 export const API_URL = process.env.NEXT_PUBLIC_API_URL ||
       (globalThis.document?.location.host.endsWith('.strapidemo.com') ? `https://${document.location.host.replace('client-', 'api-')}` : '');
+
+// Strapi's content source maps (sent in draft mode) append invisible stega
+// markers to every string so the admin preview can locate fields in the DOM.
+// They are only valid inside visible text nodes — in URLs or other attributes
+// they get percent-encoded (breaking the URL) and cause hydration mismatches.
+export const stripStegaMarkers = (value: string): string =>
+  value.replace(/[\u200B-\u200D\u2060\uFEFF]/g, '');
+
+// Blocks (rich text) content snapshots the media URL from the authoring
+// environment (e.g. http://localhost:1337/uploads/...), so any /uploads/
+// path must be rebuilt against the current Strapi host before rendering.
+export const normalizeStrapiMediaUrl = (url: string): string => {
+  const cleanUrl = stripStegaMarkers(url);
+  try {
+    const { pathname } = new URL(cleanUrl, API_URL || 'http://localhost');
+    if (pathname.startsWith('/uploads/')) {
+      return API_URL + pathname;
+    }
+  } catch {
+    // not a parseable URL; render it unchanged
+  }
+  return cleanUrl;
+};


### PR DESCRIPTION
Fixes #126

## Problem

Images inserted through the rich-text (blocks) editor showed up in dev but 404'd in production — both on the public site and in the admin preview pane.

**Root cause.** Strapi stores images two different ways:

| | Storage | URL resolution |
|---|---|---|
| **Media field** (e.g. article cover) | Relation to the `files` table, which holds a relative path (`/uploads/rocket_4_55fae57ea4.png`) | Resolved against the serving host on every request — always correct |
| **Blocks (rich text) image** | Full snapshot of the media object frozen into the content JSON at insert time — **absolute URL included** | Never recomputed — replays whatever host was frozen in |

The seeded articles were authored on a machine running Strapi locally, so the blocks JSON in every environment literally contains:

```json
"name": "rocket-4.png",
"url": "http://localhost:1337/uploads/rocket_4_55fae57ea4.png"
```

The default `BlocksRenderer` image block renders that URL verbatim (`<img src={image.url}>`). In a visitor's browser, `localhost:1337` points at the **visitor's own machine**, so block images only ever worked on a machine that happened to run Strapi at `localhost:1337` — i.e. dev. The files themselves were never missing: the same image exists on the prod host (verified 200), nothing just pointed at it.

**A second, related bug** surfaced while debugging: in draft-mode preview, Strapi's content source maps append invisible stega characters (`​`–`‍`, `⁠`, `﻿`) to every string so the admin can map rendered text back to fields. Inside a URL these get percent-encoded — breaking the image in the preview pane — and they caused hydration mismatches on `src` attributes in the preview iframe.

## Changes

### 1. Render-time URL normalization — `next/lib/utils.ts`

`normalizeStrapiMediaUrl()` makes block-image rendering host-agnostic: it parses the stored URL, throws away whatever host was snapshotted in, and rebuilds any `/uploads/` path against the current `API_URL`:

| Stored in content JSON | Rendered (prod, `API_URL=https://api-xxx.strapidemo.com`) |
|---|---|
| `http://localhost:1337/uploads/a.png` | `https://api-xxx.strapidemo.com/uploads/a.png` |
| `/uploads/a.png` | `https://api-xxx.strapidemo.com/uploads/a.png` |
| `https://project.media.strapiapp.com/a.png` (CDN, no `/uploads/`) | unchanged |

This is the same recomputation media fields get for free — applied to block images at render time. It also future-proofs content authored in prod and viewed elsewhere (the snapshot problem is symmetric: whatever host gets frozen in is wrong everywhere else).

### 2. Custom image block — `next/components/article-content.tsx` (new)

The blog page previously rendered `<BlocksRenderer content={article.content} />` with the default image block, which uses the stored URL verbatim. `ArticleContent` is a small client wrapper (required: `BlocksRenderer` is a client component, so the server page can't pass component overrides directly) that overrides only the `image` block:

- URL goes through `normalizeStrapiMediaUrl()`
- renders via `next/image` with the node's real `width`/`height` instead of a raw `<img>`
- alt text is cleaned of stega markers

All other block types (paragraphs, headings, lists, quotes, code) keep the default renderers.

### 3. Stega stripping in every media-URL helper

`stripStegaMarkers()` (in `next/lib/utils.ts`) removes the invisible source-map characters. Applied in all three URL helpers so no media URL can carry them into an attribute:

- `next/lib/strapi/strapiImage.ts` → `strapiImage()`
- `next/components/ui/strapi-media.tsx` → `getStrapiMedia()`
- `next/lib/utils.ts` → `normalizeStrapiMediaUrl()`

Markers remain in visible *text* (they're load-bearing for the preview's click-to-edit), but never in URLs, `src`, or `alt`.

### 4. Clean seed data — `strapi/data/export_20250116105447.tar.gz`

The frontend fix can't help the **admin editor**, which renders the stored JSON directly — and the seed file kept re-importing localhost URLs into every freshly provisioned environment (the demo deploy re-seeds from this archive). So the data was fixed at the source:

- Rewrote the snapshotted URLs in the 3 affected article rows (EN draft, FR draft, FR published — 6 image URLs total) to relative `/uploads/...` paths, which resolve correctly in the admin of any environment (the admin is same-origin with the API).
- Regenerated the export from the cleaned database.

## Verification

- **Cross-host production test:** `next build` + `next start` with an API host deliberately *different* from the one stored in the content JSON — block image URLs were rewritten to the runtime host and fetched with 200.
- **Export integrity:** the regenerated archive was extracted and field-diffed against the previous one — the only content changes are the 6 image URLs; entity counts, asset counts and all other field values are identical (internal component id renumbering is a normal import artifact).
- **Live demo:** the deployed image optimizer already accepts the `api-*.strapidemo.com` host and `NEXT_PUBLIC_API_URL` resolution works (checked against the running demo), so no deployment config changes are needed.

## Out of scope: recoverable hydration error in the admin preview

While working in the draft-mode preview you may still see a **"Recoverable Error: Hydration failed"** overlay on text fields (e.g. the footer description). This is **not addressed by this PR**, and is unrelated to the image fix. What we established while investigating:

- The cause is Strapi's visual-editing script, which rewrites text nodes (stripping content-source-map stega markers, adding `data-strapi-source` attributes) while React is still hydrating streamed content. The integration in this repo follows the [official Strapi preview pattern](https://docs.strapi.io/cms/features/preview) — the race is inherent to that pattern; a page with the script not injected shows zero hydration errors.
- **Dev-only presentation, no production impact.** Verified against a production build: the same mismatch occurs but is a single console-only minified React #418 message; React recovers automatically, nothing is user-visible, and the public site (no draft mode) is never affected.
- A potential follow-up fix exists (defer the `previewReady` handshake until the streamed DOM settles, verified to eliminate the error in testing) and can be proposed as a separate PR to keep this one focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)