### PR TITLE
fix: restore live-preview click-to-edit for media (#132)

### DIFF
--- a/next/components/article-content.tsx
+++ b/next/components/article-content.tsx
@@ -8,6 +8,7 @@ import type { ComponentProps } from 'react';
 
 import { BlurImage } from './blur-image';
 import { normalizeStrapiMediaUrl, stripStegaMarkers } from '@/lib/utils';
+import { getStrapiSource } from '@/lib/strapi/sourceMap';
 
 type BlockComponents = NonNullable<
   ComponentProps<typeof BlocksRenderer>['blocks']
@@ -20,6 +21,9 @@ const ImageBlock: BlockComponents['image'] = ({ image }) => (
     width={image.width}
     height={image.height}
     className="rounded-lg"
+    // Decode from the raw url before normalizeStrapiMediaUrl cleans it, so the
+    // preview overlay can map this block image back to its media field.
+    data-strapi-source={getStrapiSource(image.url)}
   />
 );
 

--- a/next/components/blog-card.tsx
+++ b/next/components/blog-card.tsx
@@ -6,7 +6,7 @@ import Balancer from 'react-wrap-balancer';
 
 import { Logo } from './logo';
 import { BlurImage } from '@/components/blur-image';
-import { strapiImage } from '@/lib/strapi/strapiImage';
+import { resolveStrapiMedia } from '@/lib/strapi/strapiImage';
 import { truncate } from '@/lib/utils';
 import { Article } from '@/types/types';
 
@@ -25,7 +25,7 @@ export const BlogCard = ({
       <div className="">
         {article.image ? (
           <BlurImage
-            src={strapiImage(article.image.url)}
+            {...resolveStrapiMedia(article.image.url)}
             alt={article.title}
             height="1200"
             width="1200"
@@ -90,7 +90,7 @@ export const BlogCardVertical = ({
       <div className="">
         {article.image ? (
           <BlurImage
-            src={strapiImage(article.image.url || '')}
+            {...resolveStrapiMedia(article.image.url)}
             alt={article.title}
             height="800"
             width="800"

--- a/next/components/logo.tsx
+++ b/next/components/logo.tsx
@@ -2,7 +2,7 @@ import { Link } from 'next-view-transitions';
 import React from 'react';
 
 import { BlurImage } from './blur-image';
-import { strapiImage } from '@/lib/strapi/strapiImage';
+import { resolveStrapiMedia } from '@/lib/strapi/strapiImage';
 import { Image } from '@/types/types';
 
 export const Logo = ({ image, locale }: { image?: Image; locale?: string }) => {
@@ -13,7 +13,7 @@ export const Logo = ({ image, locale }: { image?: Image; locale?: string }) => {
         className="font-normal flex space-x-2 items-center text-sm mr-4  text-black   relative z-20"
       >
         <BlurImage
-          src={strapiImage(image?.url)}
+          {...resolveStrapiMedia(image?.url)}
           alt={image.alternativeText}
           width={200}
           height={200}

--- a/next/components/products/single-product.tsx
+++ b/next/components/products/single-product.tsx
@@ -22,8 +22,11 @@ export const SingleProduct = ({
   addToCartText?: string;
   buyNowText?: string;
 }) => {
+  // Hold the *raw* Strapi URL so StrapiMedia can resolve it and decode the
+  // visual-editing source mapping. Passing a pre-cleaned URL here would strip
+  // the markers before StrapiMedia could read them.
   const [activeThumbnail, setActiveThumbnail] = useState(
-    strapiImage(product.images[0].url)
+    product.images[0].url
   );
   const { addToCart } = useCart();
 
@@ -58,7 +61,7 @@ export const SingleProduct = ({
             {product.images &&
               product.images.map((image, index) => (
                 <button
-                  onClick={() => setActiveThumbnail(strapiImage(image.url))}
+                  onClick={() => setActiveThumbnail(image.url)}
                   key={'product-image' + index}
                   className={cn(
                     'h-20 w-20 rounded-xl',

--- a/next/components/ui/strapi-media.tsx
+++ b/next/components/ui/strapi-media.tsx
@@ -1,4 +1,5 @@
 import { API_URL, stripStegaMarkers } from '@/lib/utils';
+import { getStrapiSource } from '@/lib/strapi/sourceMap';
 import { unstable_noStore as noStore } from 'next/cache';
 import Image from 'next/image';
 import {
@@ -41,6 +42,11 @@ export function StrapiMedia({
 }: Readonly<StrapiMediaProps>) {
   noStore();
 
+  // Decode the visual-editing source from the raw URL *before* getStrapiMedia
+  // strips the markers, and render it as a literal data attribute the preview
+  // overlay reads directly. Undefined outside draft mode -> attribute omitted.
+  const strapiSource = getStrapiSource(src);
+
   if (mime?.startsWith('video/')) {
     const url = getStrapiMedia(src);
     if (!url) return null;
@@ -50,6 +56,7 @@ export function StrapiMedia({
         controls
         preload="metadata"
         className={className}
+        data-strapi-source={strapiSource}
         {...videoProps}
       />
     );
@@ -59,7 +66,13 @@ export function StrapiMedia({
     const url = getStrapiMedia(src);
     if (!url) return null;
     return (
-      <audio src={url} controls className={className} {...audioProps} />
+      <audio
+        src={url}
+        controls
+        className={className}
+        data-strapi-source={strapiSource}
+        {...audioProps}
+      />
     );
   }
 
@@ -70,6 +83,7 @@ export function StrapiMedia({
       src={imageUrl}
       alt={alt ?? 'No alternative text provided'}
       className={className}
+      data-strapi-source={strapiSource}
       {...imageProps}
     />
   );

--- a/next/lib/strapi/sourceMap.ts
+++ b/next/lib/strapi/sourceMap.ts
@@ -1,0 +1,64 @@
+import { vercelStegaDecode } from '@vercel/stega';
+
+/**
+ * Strapi's live-preview visual editing works by embedding "content source maps"
+ * — invisible stega markers — into every string field when the frontend requests
+ * them in draft mode (`strapi-encode-source-maps: true`). Strapi's preview script
+ * (injected into the iframe) normally decodes those markers straight out of an
+ * <img>'s `src` attribute to learn which field the image maps to.
+ *
+ * That decode-from-src path is fragile. In dev the markers survive (next/image
+ * runs `unoptimized`, emitting a plain <img> with the verbatim URL), so it works.
+ * But an optimized production build rewrites the src to a proxy URL
+ * (`/_next/image?url=<percent-encoded original>&w=...`), which percent-encodes the
+ * markers so they're no longer raw zero-width characters the preview script can
+ * find — so media is not click-to-editable in production. (Separately, our own
+ * URL cleaning strips the markers at render time, which breaks it everywhere.)
+ *
+ * This helper decodes the markers from the *raw* Strapi URL ourselves (before the
+ * URL is cleaned and handed to next/image) and returns the field-mapping string
+ * to render as a literal `data-strapi-source` attribute. The preview script's
+ * highlight system reads that attribute directly, so the image becomes
+ * click-to-replace without relying on markers surviving the URL.
+ *
+ * Returns `undefined` when there are no markers (e.g. production / non-draft),
+ * so callers can spread it and React simply omits the attribute.
+ */
+export function getStrapiSource(
+  url: string | null | undefined
+): string | undefined {
+  if (!url) return undefined;
+
+  let decoded: unknown;
+  try {
+    decoded = vercelStegaDecode(url);
+  } catch {
+    return undefined;
+  }
+
+  if (
+    !decoded ||
+    typeof decoded !== 'object' ||
+    !('strapiSource' in decoded) ||
+    typeof decoded.strapiSource !== 'string'
+  ) {
+    return undefined;
+  }
+
+  const source = decoded.strapiSource;
+
+  // The encoded value sits on the media's inner `url` field, so its path is e.g.
+  // `hero.url`. Strip the trailing `.url` so the highlight focuses the media
+  // field itself — mirroring exactly what Strapi's preview script does for
+  // media elements (it does the same string replace before setting the source
+  // attribute). Keep this as a string replace rather than re-serializing the
+  // params, so our output is byte-for-byte what Strapi would have produced.
+  const pathMatch = /path=([^&]+)/.exec(source);
+  if (pathMatch) {
+    const originalPath = pathMatch[1];
+    const mediaPath = originalPath.replace(/\.url$/, '');
+    return source.replace(`path=${originalPath}`, `path=${mediaPath}`);
+  }
+
+  return source;
+}

--- a/next/lib/strapi/strapiImage.ts
+++ b/next/lib/strapi/strapiImage.ts
@@ -1,5 +1,6 @@
 import { unstable_noStore as noStore } from 'next/cache';
 import { API_URL, stripStegaMarkers } from '../utils';
+import { getStrapiSource } from './sourceMap';
 
 export function strapiImage(url: string): string {
   noStore();
@@ -11,4 +12,22 @@ export function strapiImage(url: string): string {
   }
 
   return cleanUrl;
+}
+
+/**
+ * Resolve a raw Strapi media URL into the props an image element needs to be
+ * both displayable AND click-to-edit in the live preview:
+ *  - `src`: the cleaned, host-resolved URL
+ *  - `data-strapi-source`: the visual-editing field mapping, decoded from the
+ *    RAW url *before* cleaning strips it (undefined outside draft mode, so the
+ *    attribute is simply omitted in production)
+ *
+ * Spread directly onto the element so the source mapping can't be forgotten:
+ *   <BlurImage {...resolveStrapiMedia(image.url)} alt={...} width={...} />
+ */
+export function resolveStrapiMedia(url: string | null | undefined) {
+  return {
+    src: strapiImage(url ?? ''),
+    'data-strapi-source': getStrapiSource(url),
+  };
 }

--- a/next/package.json
+++ b/next/package.json
@@ -24,6 +24,7 @@
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.5.0",
     "@types/fuzzy-search": "^2.1.5",
+    "@vercel/stega": "^0.1.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -2275,6 +2275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/stega@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@vercel/stega@npm:0.1.2"
+  checksum: 10c0/66eb80f286d46806004a2eacd215af80ad3cd443e7a96a6070d390dbb3f4d1f6e063013ec0d196c7fe852721d5dbe62e23b44c32975e36b18cda30e5e0728e04
+  languageName: node
+  linkType: hard
+
 "@webgpu/types@npm:*":
   version: 0.1.64
   resolution: "@webgpu/types@npm:0.1.64"
@@ -5336,6 +5343,7 @@ __metadata:
     "@types/react": "npm:^19.2.0"
     "@types/react-dom": "npm:^19.2.0"
     "@types/three": "npm:^0.179.0"
+    "@vercel/stega": "npm:^0.1.2"
     class-variance-authority: "npm:^0.7.0"
     clsx: "npm:^2.1.1"
     date-fns: "npm:^3.6.0"


### PR DESCRIPTION
Closes #132.

## What

Restores the ability to click an image in the live preview to edit/replace its
media field. This was broken for all media; only text fields were editable.

## Why it broke

Live-preview click-to-edit works by reading a `data-strapi-source` attribute off
the rendered element. Strapi's injected preview script normally derives that
attribute by decoding content source-map markers — invisible stega characters —
embedded in the media URL.

Those markers were destroyed before the preview script could read them, via two
independent paths:

- **#131** added `stripStegaMarkers()` to the media URL helpers. It correctly
  fixed the #126 image 404s, but stripping the markers also removed the
  visual-editing field mapping as a side effect.
- Independently, **`next/image`** rewrites media URLs into its optimizer proxy
  form (`/_next/image?url=...`) in production builds, percent-encoding the markers
  out of decodable form — so this never worked in optimized production, even
  before #131. (It worked in local dev only because dev runs `next/image`
  unoptimized and the URL was passed through untouched.)

## The fix

Instead of relying on the markers surviving inside the URL, decode the field
mapping from the **raw** URL ourselves and render it as an explicit
`data-strapi-source` attribute the overlay reads directly:

- add `getStrapiSource()` to decode the mapping from a raw media URL (strips the
  trailing `.url` so the highlight focuses the media field, matching Strapi's
  preview script), and `resolveStrapiMedia()` to pair it with the cleaned `src`
- emit the attribute from `StrapiMedia` (covers ~10 call sites), the article
  block-image renderer, blog cards, the logo, and the single-product image
- keep the raw URL in `single-product` state so `StrapiMedia` can decode it

**This keeps every URL fix from #131 intact** (markers are still stripped from the
`src`, host is still rebuilt, no 404s) and additionally makes click-to-edit work
in optimized production builds, where it previously did not.

Adds `@vercel/stega@0.1.2` (the same codec Strapi uses) to decode the markers.

## Test plan

- [ ] Blog post body image: double-click in preview opens the media field
- [ ] Blog index card image: click opens the article image field
- [ ] Navbar logo: click opens the logo media field
- [ ] Single product main image: click opens the product image field
- [ ] Hero/cover images (StrapiMedia): highlight + click-to-edit
- [ ] Production build: media still loads (no 404s) and is click-to-edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)