### PR TITLE
fix: shim missing helper so live-preview click-to-edit works in production

### DIFF
--- a/next/components/preview.tsx
+++ b/next/components/preview.tsx
@@ -18,8 +18,32 @@ export const Preview = () => {
       if (data.type === 'strapiUpdate') {
         router.refresh();
       } else if (data.type === 'strapiScript') {
+        const src: string = data.payload.script;
+        // Workaround for a Strapi bug: the production admin build's injected
+        // live-preview highlight script calls a minified bundler helper — a
+        // lazy-import wrapper around `import('@vercel/stega')`, e.g.
+        // `await ye(async () => { ... })` (renamed to `be` and so on in later
+        // builds) — that it never includes in the emitted script. The helper is
+        // undefined at runtime, so the script throws
+        // `ReferenceError: <name> is not defined`, its init promise rejects with
+        // no catch, and click-to-edit never wires up (no overlay, no field
+        // selection). It works under `strapi develop` because that build inlines
+        // the helper. The name is minified and changes between Strapi builds, so
+        // parse every `await NAME(async ...)` helper out of the script and define
+        // each as a passthrough that just runs the factory. Helpers the script
+        // defines locally simply shadow these globals, so this is safe. Remove
+        // once Strapi ships a build that self-contains the helper.
+        const w = window as unknown as Record<string, unknown>;
+        for (const match of src.matchAll(
+          /await\s+([A-Za-z_$][\w$]*)\s*\(\s*async/g
+        )) {
+          const name = match[1];
+          if (typeof w[name] === 'undefined') {
+            w[name] = (factory: () => unknown) => factory();
+          }
+        }
         const script = window.document.createElement('script');
-        script.textContent = data.payload.script;
+        script.textContent = src;
         window.document.head.appendChild(script);
       }
     };


### PR DESCRIPTION
## Summary

Live-preview **click-to-edit** silently breaks in **production** (works fine under `strapi develop`). The rendered preview loads, but hovering/clicking text or media never highlights or selects a field.

## Root cause

Strapi's **production** admin build injects a live-preview highlight script into the preview iframe. That script calls a minified bundler helper — a lazy-import wrapper around `import('@vercel/stega')` — but **never includes the helper in the emitted script string**:

```js
const { vercelStegaDecode, vercelStegaClean } = await ye(async () => {
  const { vercelStegaDecode, vercelStegaClean } =
    await import("https://cdn.jsdelivr.net/npm/@vercel/stega@.../+esm");
  return { vercelStegaDecode, vercelStegaClean };
}, []);
```

`ye` is undefined at runtime → `ReferenceError: ye is not defined`. The script's init promise rejects with **no `.catch`**, so the entire highlight/click system never initializes (no overlay, no `data-strapi-source` tagging, no field selection). It works in dev because the dev build inlines the helper.

The minified name is **not stable** — it changes between Strapi builds (observed `ye` → `be`), so it can't be hardcoded.

## ⚠️ This is a workaround — the real fix belongs in Strapi core

This PR is a **temporary client-side shim** to unblock click-to-edit. The actual bug is in Strapi's admin build (it emits a script referencing a helper it doesn't bundle). **A separate issue/PR should be filed against [`strapi/strapi`](https://github.com/strapi/strapi)** so the injected preview script is self-contained. Once Strapi ships that fix, this shim should be removed.

- [ ] File upstream Strapi issue/PR for the self-contained preview script
- [ ] Remove this shim once Strapi is fixed

## What this PR does

In `Preview`, before injecting Strapi's script, parse every `await NAME(async …)` helper out of the script text and define each as a passthrough that runs the factory. Helpers the script defines locally simply shadow these globals, so it's safe and **name-agnostic** (handles `ye`, `be`, and any future rename).

## Validation

Verified end-to-end against the production Strapi admin build (helper `be`) via Playwright, driving the real admin preview iframe:

| | `data-strapi-source` els | `.strapi-highlight` els | overlay | click → admin |
|---|---|---|---|---|
| Before | 6 | 0 | ✗ | — |
| After | **50** | **34** | **✓** | **`strapiFieldSingleClickHint`** |

Reproduces on Strapi 5.47.1. Affects production deployments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)