### PR TITLE
fix(a11y): use h1 for the product title on product detail pages

### DIFF
--- a/next/components/products/single-product.tsx
+++ b/next/components/products/single-product.tsx
@@ -80,7 +80,7 @@ export const SingleProduct = ({
           </div>
         </div>
         <div>
-          <h2 className="text-2xl font-semibold mb-4">{product.name}</h2>
+          <h1 className="text-2xl font-semibold mb-4">{product.name}</h1>
           <p className=" mb-6 bg-white text-xs px-4 py-1 rounded-full text-black w-fit">
             {locale === 'fr' ? '€' : '$'}
             {formatNumber(product.price, locale)}

--- a/tanstack/src/components/products/single-product.tsx
+++ b/tanstack/src/components/products/single-product.tsx
@@ -75,7 +75,7 @@ export const SingleProduct = ({
           </div>
         </div>
         <div>
-          <h2 className="text-2xl font-semibold mb-4">{product.name}</h2>
+          <h1 className="text-2xl font-semibold mb-4">{product.name}</h1>
           <p className=" mb-6 bg-white text-xs px-4 py-1 rounded-full text-black w-fit">
             {locale === 'fr' ? '€' : '$'}
             {formatNumber(product.price, locale)}


### PR DESCRIPTION
Product detail pages rendered the product name as `<h2>`, leaving the page
with **no `<h1>` at all**. A page should have exactly one `h1`, and
screen-reader users navigate by it.

**Draft for review — please do not merge yet.**

## The change

Two lines:

| File | Change |
| --- | --- |
| `next/components/products/single-product.tsx:83` | `<h2>` → `<h1>` |
| `tanstack/src/components/products/single-product.tsx:78` | `<h2>` → `<h1>` |

Astro and Nuxt already used `<h1>` and are unchanged, so this also brings
all four frontends to the same heading structure.

## Verified

Each frontend was run against the shared Strapi and its live product page
checked for exactly one `h1` carrying the product name:

| Frontend | h1 count | Content |
| --- | --- | --- |
| Next | 1 | Analytics Insight Pack |
| Astro | 1 | Analytics Insight Pack |
| Nuxt | 1 | Analytics Insight Pack |
| TanStack | 1 | Analytics Insight Pack |

Before this change, Next and TanStack each returned `h1 count = 0`.

## Note

`next/components/products/single-product.tsx` fails `yarn check:format`,
but it already does so on `main` — 23 files do. I left it alone rather
than bundle an unrelated reformat into a one-line fix.

## Stacking

Targets `feat/tanstack-frontend` (#150), so the diff above is just this
fix. **Merge #150 first** — GitHub will retarget this PR to `main`
automatically once it does.
