### PR TITLE
fix(nuxt): only send the source-map header in draft mode

### DIFF
--- a/nuxt/shared/lib/strapi.ts
+++ b/nuxt/shared/lib/strapi.ts
@@ -95,13 +95,19 @@ export function createStrapiClient(baseUrl: string): StrapiClient {
     const url = `${apiUrl}/${path}${buildQuery(options)}`;
 
     const response = await fetch(url, {
-      headers: {
-        // Only meaningful in draft mode: tells Strapi to embed invisible stega
-        // markers so its preview overlay can locate each field in the DOM.
-        // See `shared/lib/source-map.ts` for how those are handled on the way
-        // out.
-        'strapi-encode-source-maps': options.draft ? 'true' : 'false',
-      },
+      // Only sent in draft mode, where it tells Strapi to embed invisible
+      // stega markers so its preview overlay can locate each field in the DOM.
+      // See `shared/lib/source-map.ts` for how those are handled on the way
+      // out.
+      //
+      // Sending it as "false" the rest of the time is not free. Nuxt refetches
+      // on the client during in-app navigation, and any custom header makes
+      // that a preflighted cross-origin request. Strapi's CORS defaults allow
+      // only Content-Type, Authorization, Origin and Accept, so the preflight
+      // fails, the fetch throws, and the page renders its 404 — while a full
+      // page load of the same URL works, because that fetch runs on the
+      // server. Omitting the header keeps it a simple request.
+      headers: options.draft ? { 'strapi-encode-source-maps': 'true' } : {},
     });
 
     if (!response.ok) {


### PR DESCRIPTION
Clicking a nav link to a CMS page in the Nuxt demo renders the 404. Loading
the same URL directly, or reloading it, works.

## What is happening

The difference is where the fetch runs. A full page load fetches Strapi on
the server; in-app navigation refetches from the browser.

That browser request carried `strapi-encode-source-maps: false`, and any
custom header makes a cross-origin request preflighted. Strapi's CORS
defaults answer with:

```
Access-Control-Allow-Headers: Content-Type,Authorization,Origin,Accept
```

The header is not in that list, so the preflight fails, the fetch throws,
`page.value` is null, and the page throws its own 404 — which is why the
symptom looks like a missing route rather than a blocked request.

Confirmed against Strapi directly:

```
preflight with the header  → 204, header not in Allow-Headers
plain GET without it       → 200
```

## The fix

The header only means something when `draft` is true. Sending `"false"` the
rest of the time bought nothing and cost every client-side navigation.
Omitting it keeps those requests simple, so no preflight happens.

Draft mode still sends it, so the preview overlay is unaffected.

## Why only Nuxt

Next, Astro and TanStack set the same header unconditionally but never hit
this, because none of them fetch Strapi from the browser — RSC, SSR and
server functions respectively. Left alone rather than changed
speculatively.

## Verification

By click-through, not direct loads, since direct loads always worked:
`/en/pricing`, `/en/contact` and `/en/faq` all render, with zero CORS errors
in the console. Nuxt build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQSJu9Etpa6qjCny1CPWcc